### PR TITLE
fix: Zeroize plaintext on AES-GCM decryption failure

### DIFF
--- a/src/cbmpc/crypto/base.h
+++ b/src/cbmpc/crypto/base.h
@@ -164,9 +164,11 @@ void random_shuffle(buf128_t key, T& v, int count) {
   }
 }
 
-class aes_gcm_t : public evp_cipher_ctx_t {
- public:
-  aes_gcm_t() : evp_cipher_ctx_t() {}
+class aes_gcm_t {
+ private:
+  evp_cipher_ctx_t cipher;
+
+  aes_gcm_t() = default;
   void encrypt_init(mem_t key, mem_t iv, mem_t auth);
   void encrypt_final(mem_t tag);  // tag.data is output
 
@@ -175,6 +177,7 @@ class aes_gcm_t : public evp_cipher_ctx_t {
 
   void reinit(mem_t iv, mem_t auth);
 
+ public:
   static void encrypt(mem_t key, mem_t iv, mem_t auth, int tag_size, mem_t in, buf_t& out);
   static error_t decrypt(mem_t key, mem_t iv, mem_t auth, int tag_size, mem_t in, buf_t& out);
 };


### PR DESCRIPTION
Previously, the AES-GCM `decrypt_final` function did not zeroize the decrypted plaintext from memory when the authentication tag verification failed. This could lead to sensitive data remaining in memory. We emphasize that none of the higher level protocols are impacted by this as they already zeroize the value. We are making this change for good hygiene.

This commit leverages `EVP_CIPHER_CTX` to ensure proper cleanup and zeroization of the plaintext buffer in the event of a decryption failure.