### PR TITLE
fix(network): Mismatching new/free or malloc/delete

### DIFF
--- a/cb-mpc-go/network/network.h
+++ b/cb-mpc-go/network/network.h
@@ -31,8 +31,8 @@ typedef struct JOB_SESSION_MP_PTR
   void* opaque;  // Opaque pointer to the C++ class instance
 } JOB_SESSION_MP_PTR;
 
-inline void free_job_session_2p(JOB_SESSION_2P_PTR* ptr) { free(ptr->opaque); }
-inline void free_job_session_mp(JOB_SESSION_MP_PTR* ptr) { free(ptr->opaque); }
+inline void free_job_session_2p(JOB_SESSION_2P_PTR* ptr) { delete ptr->opaque; }
+inline void free_job_session_mp(JOB_SESSION_MP_PTR* ptr) { delete ptr->opaque; }
 
 // ---------------- JOB_SESSION_2P_PTR ------------
 JOB_SESSION_2P_PTR* new_job_session_2p(data_transport_callbacks_t* callbacks, void* go_impl_ptr, int party_index);


### PR DESCRIPTION
https://github.com/coinbase/cb-mpc/blob/eb21bd16ac13e247dd26baa4b631c89d7eb817e8/cb-mpc-go/network/network.h#L34-L35

Fix the issue, the `free_job_session_2p` function should use the `delete` operator instead of `free` to deallocate the `opaque` pointer. This ensures that the memory allocated with `new` is properly deallocated, avoiding undefined behavior.

**Steps to fix:**
1. Replace the `free` call in `free_job_session_2p` with `delete`.
2. Similarly, replace the `free` call in `free_job_session_mp` with `delete`, as it also deallocates an `opaque` pointer that likely points to a C++ class instance.

#### References
[Can I free() pointers allocated with new? Can I delete pointers allocated with malloc()?](https://isocpp.org/wiki/faq/freestore-mgmt#mixing-malloc-and-delete)
[Relation to malloc and free](https://en.wikipedia.org/wiki/New_and_delete_(C%2B%2B)#Relation_to_malloc_and_free)" in new and delete (C++)
[CWE-401](https://cwe.mitre.org/data/definitions/401.html)

---



