### PR TITLE
chore: cleanup unused codes in buf128_t and buf256_t

### DIFF
--- a/src/cbmpc/core/buf128.cpp
+++ b/src/cbmpc/core/buf128.cpp
@@ -146,15 +146,6 @@ buf128_t& buf128_t::operator^=(const buf128_t& src) { return *this = *this ^ src
 buf128_t& buf128_t::operator|=(const buf128_t& src) { return *this = *this | src; }
 buf128_t& buf128_t::operator&=(const buf128_t& src) { return *this = *this & src; }
 
-void buf128_t::be_inc() {
-  byte_ptr p = byte_ptr(this) + 16;
-  for (int i = 0; i < 16; i++) {
-    byte_t x = *--p;
-    *p = ++x;
-    if (x) break;
-  }
-}
-
 void buf128_t::convert(coinbase::converter_t& converter) {
   if (converter.is_write()) {
     if (!converter.is_calc_size()) save(converter.current());
@@ -166,10 +157,6 @@ void buf128_t::convert(coinbase::converter_t& converter) {
     *this = load(converter.current());
   }
   converter.forward(16);
-}
-
-buf128_t buf128_t::galois_field_mult(const buf128_t& a, const buf128_t& b) {
-  return buf256_t::binary_galois_field_reduce(buf256_t::caryless_mul(a, b));
 }
 
 #if defined(__x86_64__)
@@ -200,6 +187,7 @@ buf128_t::reverse_bytes() const {
 }
 
 buf128_t buf128_t::operator<<(unsigned n) const {
+  cb_assert(n < 128);
   uint64_t l = lo();
   uint64_t r = hi();
   if (n == 64) {
@@ -217,6 +205,7 @@ buf128_t buf128_t::operator<<(unsigned n) const {
 }
 
 buf128_t buf128_t::operator>>(unsigned n) const {
+  cb_assert(n < 128);
   uint64_t l = lo();
   uint64_t r = hi();
   if (n == 64) {

--- a/src/cbmpc/core/buf128.h
+++ b/src/cbmpc/core/buf128.h
@@ -78,8 +78,6 @@ struct buf128_t {
   static buf128_t from_bit_index(int bit_index);
   static buf128_t mask(bool x);
 
-  void be_inc();
-
   buf128_t reverse_bytes() const;
 
   buf128_t operator<<(unsigned n) const;
@@ -91,7 +89,6 @@ struct buf128_t {
   byte_t& operator[](int index) { return (byte_ptr(this))[index]; }
 
   void convert(coinbase::converter_t& converter);
-  static buf128_t galois_field_mult(const buf128_t& a, const buf128_t& b);
 
  private:
   static buf128_t u128(u128_t val) {
@@ -100,6 +97,11 @@ struct buf128_t {
     return r;
   }
 };
+
+inline std::ostream& operator<<(std::ostream& os, const buf128_t& buf) {
+  os << "buf128_t(hi: 0x" << std::hex << buf.hi() << ", lo: 0x" << std::hex << buf.lo() << std::dec << ")";
+  return os;
+}
 
 class bufs128_ref_t {
  public:

--- a/src/cbmpc/core/buf256.h
+++ b/src/cbmpc/core/buf256.h
@@ -43,9 +43,7 @@ struct buf256_t {
   buf256_t operator>>(unsigned n) const;
   buf256_t& operator>>=(unsigned n) { return *this = *this >> n; }
 
-  void be_inc();
   static buf256_t caryless_mul(buf128_t a, buf128_t b);
-  static buf128_t binary_galois_field_reduce(buf256_t x);
 
   buf256_t reverse_bytes() const;
 

--- a/tests/unit/core/test_buf128.cpp
+++ b/tests/unit/core/test_buf128.cpp
@@ -142,24 +142,6 @@ TEST(Buf128, ReverseBytes) {
   EXPECT_EQ(b_out.lo(), 0x00FFEEDDCCBBAA99ULL);
 }
 
-TEST(Buf128, BigEndianIncrement) {
-  auto b = buf128_t::make(0ULL, 0ULL);
-
-  // be_inc should interpret b as big-endian bytes and increment
-  // For a zeroed buffer, after one increment, the last byte should become 0x01
-  b.be_inc();
-  EXPECT_TRUE(b.get_bit(120));  // LSB should be 1
-  std::cout << b.lo() << std::endl;
-  std::cout << b.hi() << std::endl;
-
-  // Enough times to flip the last few bytes
-  for (int i = 0; i < 0xFF; i++) {
-    b.be_inc();
-  }
-  EXPECT_FALSE(b.get_bit(120));
-  EXPECT_TRUE(b.get_bit(112));  // LSB should be 1
-}
-
 TEST(Buf128, FromBitIndex) {
   // from_bit_index sets single bit
   auto b = buf128_t::from_bit_index(63);

--- a/tests/unit/core/test_buf256.cpp
+++ b/tests/unit/core/test_buf256.cpp
@@ -149,22 +149,6 @@ TEST(Buf256Test, Shifts) {
   EXPECT_NE(c.lo.hi(), 0ULL);  // part of the original hi might shift into lo
 }
 
-TEST(Buf256Test, BigEndianIncrement) {
-  auto b = buf256_t::zero();
-  // Big-endian increment
-  b.be_inc();
-  // The very last byte (index 31) becomes 0x01
-  EXPECT_TRUE(b.get_bit(248));  // The 248th bit corresponds to that last byte's LSB if everything else is zero.
-
-  // Increment 0xFF times
-  for (int i = 0; i < 0xFF; ++i) {
-    b.be_inc();
-  }
-  // We expect that last byte to have wrapped around
-  EXPECT_FALSE(b.get_bit(248));
-  EXPECT_TRUE(b.get_bit(240));  // it should increment the next bits
-}
-
 TEST(Buf256Test, ReverseBytes) {
   buf128_t lo = buf128_t::make(0x1122334455667788ULL, 0x99AABBCCDDEEFF00ULL);
   buf128_t hi = buf128_t::make(0x0001020304050607ULL, 0x08090A0B0C0D0E0FULL);
@@ -206,22 +190,4 @@ TEST(Buf256Test, CarrylessMul) {
   // Not trivial to hand-check, but ensure we do not crash and we get a consistent result
   // We can simply verify it's not zero
   EXPECT_FALSE(r2 == buf256_t::zero());
-}
-
-TEST(Buf256Test, BinaryGaloisFieldReduce) {
-  // We can do a multiply, then reduce
-  auto a = buf128_t::make(0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL);
-  auto b = buf128_t::make(0x1111111111111111ULL, 0x8888888888888888ULL);
-  auto product = buf256_t::caryless_mul(a, b);
-  // reduce
-  auto reduced = buf256_t::binary_galois_field_reduce(product);
-
-  // Quick sanity check that we get a 128-bit result
-  EXPECT_NE(reduced.lo(), 0ULL);
-  // We can't easily guess the exact answer, but let's ensure it's not all zero
-  // unless it's a real property for these bits.
-  auto is_zero = (reduced.lo() == 0ULL && reduced.hi() == 0ULL);
-  // Not guaranteed to be non-zero, but let's at least confirm we got something
-  // in typical cases:
-  EXPECT_FALSE(is_zero);
 }


### PR DESCRIPTION
- Removed unused functionalities.
- Explicitly asserts on out-of-range bit shiftings (which usually lead undefined behavior)
- Overloaded stream `<<` operators to facilitate debugging.
- Fixed 128 bit shifting case for `buf256_t`.