### PR TITLE
fix: enable flexible t-of-n cryptogrpahic operations

### DIFF
--- a/cb-mpc-go/cblib/cblib.h
+++ b/cb-mpc-go/cblib/cblib.h
@@ -32,6 +32,21 @@ typedef struct CRYPTO_SS_NODE_PTR
   void* opaque;  // Opaque pointer to the C++ class instance
 } CRYPTO_SS_NODE_PTR;
 
+typedef struct CRYPTO_SS_AC_PTR
+{
+  void* opaque;  // Opaque pointer to the C++ access control instance
+} CRYPTO_SS_AC_PTR;
+
+typedef struct PARTY_SET_PTR
+{
+  void* opaque;  // Opaque pointer to the C++ party_set_t instance
+} PARTY_SET_PTR;
+
+typedef struct PARTY_MAP_PTR
+{
+  void* opaque;  // Opaque pointer to the C++ party map instance
+} PARTY_MAP_PTR;
+
 typedef struct CRYPTO_PRV_KEY_PTR
 {
   void* opaque;  // Opaque pointer to the C++ class instance
@@ -45,6 +60,9 @@ typedef struct CRYPTO_PUB_KEY_PTR
 inline void free_mpc_ecdsa2p_key(MPC_ECDSA2PC_KEY_PTR ctx) { free(ctx.opaque); }
 inline void free_mpc_ecdsamp_key(MPC_ECDSAMPC_KEY_PTR ctx) { free(ctx.opaque); }
 inline void free_crypto_ss_node(CRYPTO_SS_NODE_PTR ctx) { free(ctx.opaque); }
+inline void free_crypto_ss_ac(CRYPTO_SS_AC_PTR ctx) { free(ctx.opaque); }
+inline void free_party_set(PARTY_SET_PTR ctx) { free(ctx.opaque); }
+inline void free_party_map(PARTY_MAP_PTR ctx) { free(ctx.opaque); }
 inline void free_crypto_prv_key(CRYPTO_PRV_KEY_PTR ctx) { free(ctx.opaque); }
 inline void free_crypto_pub_key(CRYPTO_PUB_KEY_PTR ctx) { free(ctx.opaque); }
 // ------------------------- Function/Method Wrappers ----------------
@@ -76,6 +94,36 @@ int mpc_ecdsampc_sign(
     int sig_receiver,
     cmem_t* sig_mem);
 
+// ============ ECDSA MPC THRESHOLD ============
+CRYPTO_SS_AC_PTR new_access_control(CRYPTO_SS_NODE_PTR* root);
+PARTY_SET_PTR new_party_set();
+void party_set_add(PARTY_SET_PTR* set, int party_idx);
+PARTY_MAP_PTR new_party_map();
+void party_map_add(PARTY_MAP_PTR* map, cmem_t party_name, int party_idx);
+
+int eckey_dkg_mp_threshold_dkg(
+    JOB_SESSION_MP_PTR* job, 
+    int curve, 
+    cmem_t sid, 
+    CRYPTO_SS_AC_PTR* ac, 
+    PARTY_SET_PTR* quorum, 
+    MPC_ECDSAMPC_KEY_PTR* key);
+
+int eckey_key_share_mp_to_additive_share(
+    MPC_ECDSAMPC_KEY_PTR* key, 
+    CRYPTO_SS_AC_PTR* ac, 
+    cmems_t quorum_party_names,
+    MPC_ECDSAMPC_KEY_PTR* additive_key);
+
+int mpc_ecdsampc_sign_with_ot_roles(
+    JOB_SESSION_MP_PTR* j,
+    MPC_ECDSAMPC_KEY_PTR* k,
+    cmem_t msg_mem,
+    int sig_receiver,
+    cmems_t ot_role_map,
+    int n_parties,
+    cmem_t* sig_mem);
+
 // ============ PVE ================
 CRYPTO_SS_NODE_PTR new_node(int node_type, cmem_t node_name, int threshold);
 void add_child(CRYPTO_SS_NODE_PTR* parent, CRYPTO_SS_NODE_PTR* child);
@@ -84,6 +132,8 @@ int pve_quorum_decrypt(CRYPTO_SS_NODE_PTR* root_ptr, cmems_t quorum_prv_keys_lis
 int get_n_enc_keypairs(int n, cmems_t* pub_keys_ptr, cmems_t* prv_keys_ptr);
 int get_n_ec_keypairs(int n, cmems_t* prv_keys_ptr, cmems_t* pub_keys_ptr);
 int convert_ecdsa_share_to_bn_t_share(MPC_ECDSAMPC_KEY_PTR* k, cmem_t* x_ptr, cmem_t* Q_ptr);
+int serialize_ecdsa_mpc_key(MPC_ECDSAMPC_KEY_PTR* k, cmems_t* ser);
+int deserialize_ecdsa_mpc_key(cmems_t ser, MPC_ECDSAMPC_KEY_PTR* k);
 
 // ============ ZKPs =================
 int ZK_DL_Example();
@@ -91,6 +141,7 @@ int ZK_DL_Example();
 // ============ Utilities =============
 
 int ecdsa_mpc_public_key_to_string(MPC_ECDSAMPC_KEY_PTR* k, cmem_t *x_str, cmem_t *y_str);
+int ecdsa_mpc_private_key_to_string(MPC_ECDSAMPC_KEY_PTR* k, cmem_t* x_share_str);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/cb-mpc-go/network/network.h
+++ b/cb-mpc-go/network/network.h
@@ -35,7 +35,7 @@ inline void free_job_session_2p(JOB_SESSION_2P_PTR* ptr) { free(ptr->opaque); }
 inline void free_job_session_mp(JOB_SESSION_MP_PTR* ptr) { free(ptr->opaque); }
 
 // ---------------- JOB_SESSION_2P_PTR ------------
-JOB_SESSION_2P_PTR* new_job_session_2p(data_transport_callbacks_t* callbacks, void* go_impl_ptr, int party_index);
+JOB_SESSION_2P_PTR* new_job_session_2p(data_transport_callbacks_t* callbacks, void* go_impl_ptr, int party_index, char** pnames, int pname_count);
 int is_peer1(JOB_SESSION_2P_PTR* job);
 int is_peer2(JOB_SESSION_2P_PTR* job);
 int is_role_index(JOB_SESSION_2P_PTR* job, int party_index);
@@ -44,7 +44,7 @@ int mpc_2p_send(JOB_SESSION_2P_PTR* job, int receiver, const uint8_t* msg, const
 int mpc_2p_receive(JOB_SESSION_2P_PTR* job, int sender, uint8_t** msg, int* msg_len);
 
 // ---------------- JOB_SESSION_MP_PTR ------------
-JOB_SESSION_MP_PTR* new_job_session_mp(data_transport_callbacks_t* callbacks, void* go_impl_ptr, int party_count, int party_index, int job_session_id);
+JOB_SESSION_MP_PTR* new_job_session_mp(data_transport_callbacks_t* callbacks, void* go_impl_ptr, int party_count, int party_index, int job_session_id, char** pnames, int pname_count);
 int is_party(JOB_SESSION_MP_PTR* job, int party_index);
 int get_party_idx(JOB_SESSION_MP_PTR* job);
 

--- a/demos/demos-go/ecdsa-mpc-with-backup/main.go
+++ b/demos/demos-go/ecdsa-mpc-with-backup/main.go
@@ -100,7 +100,7 @@ func main() {
 	// run PVE many to many to restore each of the key shares
 	decryptedShares, err := cblib.PVE_quorum_decrypt(root, privKeys, leafCount, pubKeys, leafCount, pveBundle, Xs, dataCount, inputLabel)
 	if err != nil {
-		log.Fatal(fmt.Errorf("PVE encrypt failed, %v", err))
+		log.Fatal(fmt.Errorf("PVE decrypt failed, %v", err))
 	}
 	// convert the data back to the proper type
 	// As described in Step 6 above, this is not a complete backup solution. Therefore, we simply assert that the decrypted

--- a/demos/mocknet/runner.go
+++ b/demos/mocknet/runner.go
@@ -62,7 +62,8 @@ func (runner *MPCRunner) MPCRun2P(f MPCFunction2P, inputs []*MPCIO) ([]*MPCIO, e
 	wg.Add(runner.nParties)
 	for i := 0; i < runner.nParties; i++ {
 		go func(i int) {
-			job := network.NewJobSession2P(runner.peers[i].dataTransport, i)
+			pids := []string{"party_0", "party_1"}
+			job := network.NewJobSession2P(runner.peers[i].dataTransport, i, pids)
 			defer job.Free()
 			outs[i], errs[i] = f(job, inputs[i])
 			if errs[i] != nil { // abort job
@@ -105,7 +106,12 @@ func (runner *MPCRunner) MPCRunMP(f MPCFunctionMP, inputs []*MPCIO) ([]*MPCIO, e
 	jobSessionId := 0
 	for i := 0; i < runner.nParties; i++ {
 		go func(i int) {
-			job := network.NewJobSessionMP(runner.peers[i].dataTransport, runner.nParties, i, jobSessionId)
+			// Generate pid array for multi-party
+			pids := make([]string, runner.nParties)
+			for j := 0; j < runner.nParties; j++ {
+				pids[j] = fmt.Sprintf("party_%d", j)
+			}
+			job := network.NewJobSessionMP(runner.peers[i].dataTransport, runner.nParties, i, jobSessionId, pids)
 			defer job.Free()
 			outs[i], errs[i] = f(job, inputs[i])
 			if errs[i] != nil { // abort job

--- a/src/cbmpc/protocol/ec_dkg.h
+++ b/src/cbmpc/protocol/ec_dkg.h
@@ -56,9 +56,9 @@ struct key_share_2p_t {
 struct key_share_mp_t {
   bn_t x_share;
   ecc_point_t Q;
-  std::vector<crypto::ecc_point_t> Qis;
+  crypto::ss::party_map_t<crypto::ecc_point_t> Qis;
   ecurve_t curve;
-  party_idx_t party_index;
+  crypto::pname_t party_name;
 
   /**
    * @specs:
@@ -72,16 +72,16 @@ struct key_share_mp_t {
    */
   static error_t refresh(job_mp_t& job, buf_t& sid, const key_share_mp_t& current_key, key_share_mp_t& new_key);
 
-  error_t to_additive_share(const party_idx_t& party_new_index, const crypto::ss::ac_t ac, const int active_party_count,
-                            const crypto::ss::party_map_t<party_idx_t>& name_to_idx, key_share_mp_t& additive_share);
+  error_t to_additive_share(const crypto::ss::ac_t ac, const std::set<crypto::pname_t>& quorum_names,
+                            key_share_mp_t& additive_share);
 
  private:
   error_t reconstruct_additive_share(const mod_t& q, const crypto::ss::node_t* node,
-                                     const crypto::ss::party_map_t<party_idx_t>& name_to_idx,
-                                     bn_t& additive_share) const;
-  error_t reconstruct_pub_additive_shares(const crypto::ss::node_t* node,
-                                          const crypto::ss::party_map_t<party_idx_t>& name_to_idx, party_idx_t target,
-                                          ecc_point_t& pub_additive_shares) const;
+                                     const std::set<crypto::pname_t>& quorum_names, bn_t& additive_share,
+                                     bool& is_in_quorum) const;
+  error_t reconstruct_pub_additive_shares(const crypto::ss::node_t* node, const std::set<crypto::pname_t>& quorum_names,
+                                          crypto::pname_t target, ecc_point_t& pub_additive_shares,
+                                          bool& is_in_quorum) const;
 };
 
 struct dkg_mp_threshold_t {

--- a/src/cbmpc/protocol/ecdsa_mp.cpp
+++ b/src/cbmpc/protocol/ecdsa_mp.cpp
@@ -41,7 +41,7 @@ error_t sign(job_mp_t& job, key_t& key, mem_t msg, const party_idx_t sig_receive
   const auto& G = curve.generator();
   int theta = q.get_bits_count() + kappa;
 
-  if (key.x_share * G != key.Qis[i]) return coinbase::error(E_BADARG, "x_share does not match Qi");
+  if (key.x_share * G != key.Qis.at(job.get_name(i))) return coinbase::error(E_BADARG, "x_share does not match Qi");
   if (SUM(key.Qis) != key.Q) return coinbase::error(E_BADARG, "Q does not match the sum of Qis");
   auto h_consistency = job.uniform_msg<buf256_t>();
   h_consistency._i = crypto::sha256_t::hash(msg, key.Q, key.Qis);

--- a/src/cbmpc/protocol/mpc_job_session.h
+++ b/src/cbmpc/protocol/mpc_job_session.h
@@ -83,16 +83,17 @@ class job_session_mp_t : public job_mp_t {
   }
 
  public:
-  job_session_mp_t(party_idx_t index, std::vector<crypto::mpc_pid_t> pids, std::shared_ptr<network_t> _network_ptr,
+  job_session_mp_t(party_idx_t index, std::vector<crypto::pname_t> pnames, std::shared_ptr<network_t> _network_ptr,
                    jsid_t _jsid)
-      : job_mp_t(index, pids), network_ptr(_network_ptr), jsid(_jsid) {};
+      : job_mp_t(index, pnames), network_ptr(_network_ptr), jsid(_jsid) {};
+
   void set_network(party_idx_t party_idx, std::shared_ptr<network_t> ptr) {
     party_index = party_idx;
     network_ptr = ptr;
   }
 
   job_session_mp_t get_parallel_job(int parallel_count, jsid_t jsid) {
-    return job_session_mp_t(party_index, pids, network_ptr, jsid);
+    return job_session_mp_t(party_index, names, network_ptr, jsid);
   }
 
  protected:
@@ -102,16 +103,17 @@ class job_session_mp_t : public job_mp_t {
 
 class job_session_2p_t : public job_2p_t {
  public:
-  job_session_2p_t(party_t party, crypto::mpc_pid_t pid1, crypto::mpc_pid_t pid2, std::shared_ptr<network_t> ptr,
+  job_session_2p_t(party_t party, crypto::pname_t pname1, crypto::pname_t pname2, std::shared_ptr<network_t> ptr,
                    jsid_t id = 0)
-      : job_2p_t(party, pid1, pid2), network_ptr(ptr), jsid(id) {};
+      : job_2p_t(party, pname1, pname2), network_ptr(ptr), jsid(id) {};
+
   void set_network(party_t party, std::shared_ptr<network_t> ptr) {
     party_index = party_idx_t(party);
     network_ptr = ptr;
   }
 
   job_session_2p_t get_parallel_job(int parallel_count, jsid_t jsid) {
-    return job_session_2p_t(party_t(party_index), pids[0], pids[1], network_ptr, jsid);
+    return job_session_2p_t(party_t(party_index), names[0], names[1], network_ptr, jsid);
   }
 
   void set_parallel_count(int parallel_count) { network_ptr->set_parallel(parallel_count); }

--- a/src/cbmpc/protocol/schnorr_mp.cpp
+++ b/src/cbmpc/protocol/schnorr_mp.cpp
@@ -39,15 +39,16 @@ error_t sign_batch(job_mp_t& job, key_t& key, const std::vector<mem_t>& msgs, pa
 
   int n = job.get_n_parties();
   int i = job.get_party_idx();
+  crypto::pname_t pname = job.get_name();
   sigs.resize(msgs.size());
 
   ecurve_t curve = key.curve;
   const mod_t& q = curve.order();
   const auto& G = curve.generator();
 
-  if (key.party_index != i) return coinbase::error(E_BADARG, "Wrong role");
+  if (key.party_name != pname) return coinbase::error(E_BADARG, "Wrong role");
   if (key.Qis.size() != n) return coinbase::error(E_BADARG, "Wrong number of peers");
-  if (key.x_share * G != key.Qis[i]) return coinbase::error(E_BADARG, "x_share does not match Qi");
+  if (key.x_share * G != key.Qis.at(pname)) return coinbase::error(E_BADARG, "x_share does not match Qi");
   if (SUM(key.Qis) != key.Q) return coinbase::error(E_BADARG, "Q does not match the sum of Qis");
   auto h_consistency = job.uniform_msg<buf256_t>();
   h_consistency._i = crypto::sha256_t::hash(msgs, key.Q, key.Qis);

--- a/src/cbmpc/protocol/util.h
+++ b/src/cbmpc/protocol/util.h
@@ -30,6 +30,13 @@ static T SUM(const std::vector<std::reference_wrapper<T>>& v) {
   return s;
 }
 
+template <typename T>
+static T SUM(const std::map<coinbase::crypto::pname_t, T>& m) {
+  T s = m.begin()->second;
+  for (auto it = std::next(m.begin()); it != m.end(); ++it) s += it->second;
+  return s;
+}
+
 static bn_t SUM(const std::vector<bn_t>& v, const mod_t& q) {
   bn_t s = 0;
   for (int i = 0; i < int(v.size()); i++) MODULO(q) s += v[i];

--- a/tests/utils/local_network/mpc_runner.cpp
+++ b/tests/utils/local_network/mpc_runner.cpp
@@ -35,16 +35,16 @@ void mpc_runner_t::init_network(int n_parties) {
 mpc_runner_t::mpc_runner_t(int n_parties) : n(n_parties) {
   if (n == 2) {
     init_network(2);
-    job_2ps[0] = std::make_shared<job_session_2p_t>(party_t::p1, test_pids[0], test_pids[1],
+    job_2ps[0] = std::make_shared<job_session_2p_t>(party_t::p1, test_pnames[0], test_pnames[1],
                                                     std::make_shared<network_t>(get_data_transport_ptr(0)), 0);
-    job_2ps[1] = std::make_shared<job_session_2p_t>(party_t::p2, test_pids[0], test_pids[1],
+    job_2ps[1] = std::make_shared<job_session_2p_t>(party_t::p2, test_pnames[0], test_pnames[1],
                                                     std::make_shared<network_t>(get_data_transport_ptr(1)), 0);
   } else {
     if (n == -2) n = 2;
     init_network(n);
-    std::vector<bn_t> pids(test_pids.begin(), test_pids.begin() + n);
+    std::vector<crypto::pname_t> pnames(test_pnames.begin(), test_pnames.begin() + n);
     for (int i = 0; i < n; i++) {
-      job_mps[i] = std::make_shared<job_session_mp_t>(party_idx_t(i), pids,
+      job_mps[i] = std::make_shared<job_session_mp_t>(party_idx_t(i), pnames,
                                                       std::make_shared<network_t>(get_data_transport_ptr(i)), 0);
     }
   }
@@ -133,7 +133,7 @@ void mpc_runner_t::run_mpc(lambda_mp_t f) {
 void mpc_runner_t::run_2pc_parallel_helper(std::shared_ptr<network_t> network, party_t role, int th_i,
                                            lambda_2p_parallel_t f) {
   jsid_t jsid = th_i;
-  job_session_2p_t job(role, test_pids[0], test_pids[1], network, jsid);
+  job_session_2p_t job(role, test_pnames[0], test_pnames[1], network, jsid);
   f(job, th_i);
 }
 
@@ -152,8 +152,8 @@ void mpc_runner_t::run_2pc_parallel(int n_threads, lambda_2p_parallel_t f) {
 void mpc_runner_t::run_mpc_parallel_helper(int n, std::shared_ptr<network_t> network, party_idx_t party_index, int th_i,
                                            lambda_mp_parallel_t f) {
   jsid_t jsid = th_i;
-  std::vector<crypto::bn_t> pids(test_pids.begin(), test_pids.begin() + n);
-  job_session_mp_t job(party_index, pids, network, jsid);
+  std::vector<crypto::pname_t> pnames(test_pnames.begin(), test_pnames.begin() + n);
+  job_session_mp_t job(party_index, pnames, network, jsid);
   f(job, th_i);
 }
 
@@ -173,37 +173,16 @@ std::shared_ptr<local_data_transport_t> mpc_runner_t::get_data_transport_ptr(par
   return data_transports[role];
 }
 
-const std::vector<crypto::bn_t> mpc_runner_t::test_pids = {
-    crypto::pid_from_name("test party 1"),  crypto::pid_from_name("test party 2"),
-    crypto::pid_from_name("test party 3"),  crypto::pid_from_name("test party 4"),
-    crypto::pid_from_name("test party 5"),  crypto::pid_from_name("test party 6"),
-    crypto::pid_from_name("test party 7"),  crypto::pid_from_name("test party 8"),
-    crypto::pid_from_name("test party 9"),  crypto::pid_from_name("test party 10"),
-    crypto::pid_from_name("test party 11"), crypto::pid_from_name("test party 12"),
-    crypto::pid_from_name("test party 13"), crypto::pid_from_name("test party 14"),
-    crypto::pid_from_name("test party 15"), crypto::pid_from_name("test party 16"),
-    crypto::pid_from_name("test party 17"), crypto::pid_from_name("test party 18"),
-    crypto::pid_from_name("test party 19"), crypto::pid_from_name("test party 20"),
-    crypto::pid_from_name("test party 21"), crypto::pid_from_name("test party 22"),
-    crypto::pid_from_name("test party 23"), crypto::pid_from_name("test party 24"),
-    crypto::pid_from_name("test party 25"), crypto::pid_from_name("test party 26"),
-    crypto::pid_from_name("test party 27"), crypto::pid_from_name("test party 28"),
-    crypto::pid_from_name("test party 29"), crypto::pid_from_name("test party 30"),
-    crypto::pid_from_name("test party 31"), crypto::pid_from_name("test party 32"),
-    crypto::pid_from_name("test party 33"), crypto::pid_from_name("test party 34"),
-    crypto::pid_from_name("test party 35"), crypto::pid_from_name("test party 36"),
-    crypto::pid_from_name("test party 37"), crypto::pid_from_name("test party 38"),
-    crypto::pid_from_name("test party 39"), crypto::pid_from_name("test party 40"),
-    crypto::pid_from_name("test party 41"), crypto::pid_from_name("test party 42"),
-    crypto::pid_from_name("test party 43"), crypto::pid_from_name("test party 44"),
-    crypto::pid_from_name("test party 45"), crypto::pid_from_name("test party 46"),
-    crypto::pid_from_name("test party 47"), crypto::pid_from_name("test party 48"),
-    crypto::pid_from_name("test party 49"), crypto::pid_from_name("test party 50"),
-    crypto::pid_from_name("test party 51"), crypto::pid_from_name("test party 52"),
-    crypto::pid_from_name("test party 53"), crypto::pid_from_name("test party 54"),
-    crypto::pid_from_name("test party 55"), crypto::pid_from_name("test party 56"),
-    crypto::pid_from_name("test party 57"), crypto::pid_from_name("test party 58"),
-    crypto::pid_from_name("test party 59"), crypto::pid_from_name("test party 60"),
-    crypto::pid_from_name("test party 61"), crypto::pid_from_name("test party 62"),
-    crypto::pid_from_name("test party 63"), crypto::pid_from_name("test party 64")};
+const std::vector<crypto::pname_t> mpc_runner_t::test_pnames = {
+    "test party 1",  "test party 2",  "test party 3",  "test party 4",  "test party 5",  "test party 6",
+    "test party 7",  "test party 8",  "test party 9",  "test party 10", "test party 11", "test party 12",
+    "test party 13", "test party 14", "test party 15", "test party 16", "test party 17", "test party 18",
+    "test party 19", "test party 20", "test party 21", "test party 22", "test party 23", "test party 24",
+    "test party 25", "test party 26", "test party 27", "test party 28", "test party 29", "test party 30",
+    "test party 31", "test party 32", "test party 33", "test party 34", "test party 35", "test party 36",
+    "test party 37", "test party 38", "test party 39", "test party 40", "test party 41", "test party 42",
+    "test party 43", "test party 44", "test party 45", "test party 46", "test party 47", "test party 48",
+    "test party 49", "test party 50", "test party 51", "test party 52", "test party 53", "test party 54",
+    "test party 55", "test party 56", "test party 57", "test party 58", "test party 59", "test party 60",
+    "test party 61", "test party 62", "test party 63", "test party 64"};
 }  // namespace coinbase::testutils

--- a/tests/utils/local_network/mpc_runner.h
+++ b/tests/utils/local_network/mpc_runner.h
@@ -45,7 +45,7 @@ class mpc_runner_t {
   void run_mpc_parallel(int n_threads, lambda_mp_parallel_t f);
 
   // In-class declaration (no initializer):
-  static const std::vector<crypto::bn_t> test_pids;
+  static const std::vector<crypto::pname_t> test_pnames;
 
  private:
   lambda_role_t protocol_f;

--- a/tests/utils/local_network/mpc_tester.h
+++ b/tests/utils/local_network/mpc_tester.h
@@ -7,10 +7,10 @@ namespace coinbase::testutils {
 class Network2PC : public testing::Test {
  protected:
   void SetUp() override {
-    auto job1 = std::make_shared<mpc::job_session_2p_t>(mpc::party_t::p1, mpc_runner_t::test_pids[0],
-                                                        mpc_runner_t::test_pids[1], nullptr, 0);
-    auto job2 = std::make_shared<mpc::job_session_2p_t>(mpc::party_t::p2, mpc_runner_t::test_pids[0],
-                                                        mpc_runner_t::test_pids[1], nullptr, 0);
+    auto job1 = std::make_shared<mpc::job_session_2p_t>(mpc::party_t::p1, mpc_runner_t::test_pnames[0],
+                                                        mpc_runner_t::test_pnames[1], nullptr, 0);
+    auto job2 = std::make_shared<mpc::job_session_2p_t>(mpc::party_t::p2, mpc_runner_t::test_pnames[0],
+                                                        mpc_runner_t::test_pnames[1], nullptr, 0);
     mpc_runner = std::make_unique<mpc_runner_t>(job1, job2);
   }
 
@@ -29,9 +29,10 @@ class NetworkMPC : public testing::TestWithParam<int> {
   void SetUp() override {
     int n_parties = GetParam();
     std::vector<std::shared_ptr<mpc::job_session_mp_t>> jobs(n_parties);
-    std::vector<crypto::bn_t> pids(mpc_runner_t::test_pids.begin(), mpc_runner_t::test_pids.begin() + n_parties);
+    std::vector<crypto::pname_t> pnames(mpc_runner_t::test_pnames.begin(),
+                                        mpc_runner_t::test_pnames.begin() + n_parties);
     for (int i = 0; i < n_parties; i++) {
-      jobs[i] = std::make_shared<mpc::job_session_mp_t>(mpc::party_idx_t(i), pids, nullptr, 0);
+      jobs[i] = std::make_shared<mpc::job_session_mp_t>(mpc::party_idx_t(i), pnames, nullptr, 0);
     }
     mpc_runner = std::make_unique<mpc_runner_t>(jobs);
   }

--- a/tools/benchmark/mpc_util.h
+++ b/tools/benchmark/mpc_util.h
@@ -35,7 +35,7 @@ class bm_job_2p_t : public mpc::job_session_2p_t {
   // constructor that takes extra parameter -- target_round, then call the parent constructor
   bm_job_2p_t(mpc::party_t bm_party, int bm_round, mpc::party_t party, std::shared_ptr<mpc::network_t> _network_ptr,
               std::shared_ptr<abort_channel_t> abort_channel)
-      : job_session_2p_t(party, testutils::mpc_runner_t::test_pids[0], testutils::mpc_runner_t::test_pids[1],
+      : job_session_2p_t(party, testutils::mpc_runner_t::test_pnames[0], testutils::mpc_runner_t::test_pnames[1],
                          _network_ptr, 0),
         bm_party(bm_party),
         bm_round(bm_round),
@@ -233,8 +233,8 @@ class bm_job_mp_t : public mpc::job_session_mp_t {
               mpc::party_idx_t index, std::shared_ptr<mpc::network_t> _network_ptr,
               std::shared_ptr<abort_channel_mp_t> abort_channel)
       : job_session_mp_t(index,
-                         std::vector<crypto::mpc_pid_t>(testutils::mpc_runner_t::test_pids.begin(),
-                                                        testutils::mpc_runner_t::test_pids.begin() + _parties),
+                         std::vector<crypto::pname_t>(testutils::mpc_runner_t::test_pnames.begin(),
+                                                      testutils::mpc_runner_t::test_pnames.begin() + _parties),
                          _network_ptr, 0),
         bm_party(bm_party),
         bm_round(bm_round),


### PR DESCRIPTION
Originally, the t parties in a t-of-n cryptographic operations (e.g. DKG) have to be first t parties, since they were identified by their numerical indices. In this change. We refactor job*_t to use (unique) party name and use it as the only way to identify a party robustly. The indices are only used within a session of a protocol execution but not used as part of a persistent storage.

Go bindings are changed accordingly.