### PR TITLE
refactor: Crypto hardening and code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ Please note that all cryptographic code has a specification (except for code lik
 
 # Design Principles and Secure Usage
 
+> **Thread-Safety Warning**
+>
+> This library is **not** inherently thread-safe. Unless explicitly documented otherwise, all data structures and functions assume **single-threaded** access. If you need to use the library from multiple threads, you **must** protect every shared object with your own synchronization primitives (e.g., `std::mutex`, channel-based message passing, etc.) to avoid data races.
+
 We have outlined our cryptographic design principles and some conventions regarding our documentation in our [design principles document](/docs/general-principles.pdf). Furthermore, our [secure usage document](/docs/secure-usage.pdf) describes important security guidelines that should be followed when using the library. Finally, we have strived to create a library that is constant-time to prevent side-channel attacks. This effort is highly dependent on the architecture of the CPU and the compiler used to build the library and therefore is not guaranteed on all platforms. We have outlined our efforts in the [constant-time document](/docs/constant-time.pdf).
 
 # External Dependencies
@@ -252,6 +256,10 @@ We have outlined our cryptographic design principles and some conventions regard
 ### Internal Header Files
 
 We have included copies of certain OpenSSL internal header files that are not exposed through OpenSSL's public API but are necessary for our implementation. These files can be found in our codebase and are used to access specific OpenSSL functionality that we require. This approach ensures we can maintain compatibility while accessing needed internal features.
+
+Note that we change the curve25519.c of the OpenSSL code to remove the static modifier to make the functions externally visible. Given access to these functions, our Curve25519 code implements a constant-time version of the curve. Therefore, we strip the leading 'static' keyword from every line in curve25519.c as follows.
+
+```sed -i -e 's/^static//' crypto/ec/curve25519.c```
 
 ### RSA OAEP Padding Modification
 

--- a/src/cbmpc/core/buf128.cpp
+++ b/src/cbmpc/core/buf128.cpp
@@ -306,7 +306,13 @@ bufs128_t& bufs128_t::operator=(const bufs128_t& src) {
 
 void bufs128_t::convert(coinbase::converter_t& converter) {
   uint32_t count = size();
+
+  if (count > converter_t::MAX_CONTAINER_ELEMENTS) {
+    converter.set_error();
+    return;
+  }
   converter.convert_len(count);
+
   if (!converter.is_write()) {
     converter.set_error();
     return;
@@ -333,6 +339,10 @@ void bufs128_t::convert(coinbase::converter_t& converter) {
 
 void bufs128_ref_t::convert(converter_t& converter) {
   cb_assert(converter.is_write());
+  if (size > converter_t::MAX_CONTAINER_ELEMENTS) {
+    converter.set_error();
+    return;
+  }
   converter.convert(size);
   int data_size = size * int(sizeof(buf128_t));
   if (!converter.is_calc_size()) memmove(converter.current(), data, data_size);

--- a/src/cbmpc/core/convert.cpp
+++ b/src/cbmpc/core/convert.cpp
@@ -205,7 +205,13 @@ void converter_t::convert(std::vector<bool>& value) {
   short count = (short)value.size();
   convert(count);
 
-  if (!write) value.resize(count);
+  if (!write) {
+    if (count < 0 || static_cast<uint32_t>(count) > MAX_CONTAINER_ELEMENTS) {
+      set_error();
+      return;
+    }
+    value.resize(count);
+  }
   for (short i = 0; i < count && !is_error(); i++) {
     bool v = value[i];
     convert(v);

--- a/src/cbmpc/core/convert.h
+++ b/src/cbmpc/core/convert.h
@@ -72,6 +72,9 @@ class converter_t {
   int get_size() const { return (int)(write ? offset : size); }
   int get_offset() const { return (int)offset; }
 
+  // Maximum number of elements allowed when (de)serializing a std::vector.
+  static constexpr uint32_t MAX_CONTAINER_ELEMENTS = 1 << 20;
+
   void convert(bool& value);
   void convert(uint8_t& value);
   void convert(uint16_t& value);
@@ -133,7 +136,13 @@ class converter_t {
     uint32_t count = (uint32_t)value.size();
     convert_len(count);
 
-    if (!write) value.resize(count);
+    if (!write) {
+      if (count > MAX_CONTAINER_ELEMENTS) {
+        set_error();
+        return;
+      }
+      value.resize(count);
+    }
     for (uint32_t i = 0; i < count && !is_error(); i++) {
       convert(value[i]);
     }

--- a/src/cbmpc/core/error.cpp
+++ b/src/cbmpc/core/error.cpp
@@ -386,7 +386,6 @@ dylog_disable_scope_t::dylog_disable_scope_t(bool enabled) {
   if (!enabled) thread_local_storage_log_disabled++;
 }
 dylog_disable_scope_t::~dylog_disable_scope_t() { thread_local_storage_log_disabled = ref_counter; }
-void disable_thread_local_storage_log() { thread_local_storage_log_disabled = 1; }
 
 void log_string_buf_t::put(const_char_ptr ptr) {
   int len = strlen(ptr);

--- a/src/cbmpc/crypto/base.cpp
+++ b/src/cbmpc/crypto/base.cpp
@@ -9,7 +9,7 @@ namespace coinbase::crypto {
 template<> void scoped_ptr_t<EVP_MD_CTX>                ::free(EVP_MD_CTX* ptr)                    { EVP_MD_CTX_destroy(ptr);                    }
 template<> void scoped_ptr_t<BIO>                       ::free(BIO* ptr)                           { BIO_free(ptr);                              }
 template<> void scoped_ptr_t<BIGNUM>                    ::free(BIGNUM* ptr)                        { BN_clear_free(ptr);                         }
-template<> void scoped_ptr_t<BN_CTX>                    ::free(BN_CTX* ptr)                        { BN_CTX_end(ptr); BN_CTX_free(ptr);          }
+template<> void scoped_ptr_t<BN_CTX>                    ::free(BN_CTX* ptr)                        { BN_CTX_free(ptr);          }
 template<> void scoped_ptr_t<EVP_CIPHER_CTX>            ::free(EVP_CIPHER_CTX* ptr)                { EVP_CIPHER_CTX_free(ptr);                   }
 template<> void scoped_ptr_t<EC_POINT>                  ::free(EC_POINT* ptr)                      { EC_POINT_clear_free(ptr);                   }
 template<> void scoped_ptr_t<EC_GROUP>                  ::free(EC_GROUP* ptr)                      { EC_GROUP_free(ptr);                         }
@@ -242,16 +242,6 @@ void aes_gcm_t::encrypt_init(mem_t key, mem_t iv, mem_t auth) {
   cb_assert(0 < EVP_CIPHER_CTX_ctrl(cipher.ctx, EVP_CTRL_GCM_SET_IVLEN, iv.size, NULL));
   cb_assert(0 < EVP_EncryptInit(cipher.ctx, NULL, key.data, iv.data));
   cb_assert(0 < EVP_CIPHER_CTX_set_padding(cipher.ctx, 0));
-  if (auth.size > 0) {
-    int out_size = 0;
-    cb_assert(0 < EVP_CipherUpdate(cipher.ctx, NULL, &out_size, auth.data, auth.size));
-  }
-}
-
-// Note: Uses the same key but changes the iv and auth data. For example in use cases such as TLS where the same session
-// key is used but with different IVs.
-void aes_gcm_t::reinit(mem_t iv, mem_t auth) {
-  cb_assert(0 < EVP_CipherInit(cipher.ctx, NULL, NULL, iv.data, -1));
   if (auth.size > 0) {
     int out_size = 0;
     cb_assert(0 < EVP_CipherUpdate(cipher.ctx, NULL, &out_size, auth.data, auth.size));

--- a/src/cbmpc/crypto/base.h
+++ b/src/cbmpc/crypto/base.h
@@ -178,8 +178,6 @@ class aes_gcm_t {
   void decrypt_init(mem_t key, mem_t iv, mem_t auth);
   error_t decrypt_final(mem_t tag);
 
-  void reinit(mem_t iv, mem_t auth);
-
  public:
   static void encrypt(mem_t key, mem_t iv, mem_t auth, int tag_size, mem_t in, buf_t& out);
   static error_t decrypt(mem_t key, mem_t iv, mem_t auth, int tag_size, mem_t in, buf_t& out);

--- a/src/cbmpc/crypto/base_bn.h
+++ b/src/cbmpc/crypto/base_bn.h
@@ -17,7 +17,6 @@ static const int BN_FLG_FIXED_TOP = 0x10000;
 
 buf_t bn_to_buf(const BIGNUM* bn);
 buf_t bn_to_buf(const BIGNUM* bn, int size);
-void bn_to_mem(const BIGNUM* bn, mem_t mem);
 
 class mod_t;
 class paillier_t;

--- a/src/cbmpc/crypto/base_ec_core.cpp
+++ b/src/cbmpc/crypto/base_ec_core.cpp
@@ -57,23 +57,6 @@ bool booth_wnaf_t::get(unsigned& value, bool& neg) {
 }
 
 #ifdef __x86_64__
-void ct_get2(__m128i* dst, const __m128i* precomp, int line_size, unsigned index) {
-  __m128i lo1, hi1, lo2, hi2;
-  lo1 = hi1 = lo2 = hi2 = _mm_setzero_si128();
-  for (unsigned i = 0; i < line_size; i++) {
-    __m128i mask = _mm_set1_epi32(-(index == i));
-    lo1 = _mm_or_si128(lo1, _mm_and_si128(mask, _mm_load_si128(precomp + 0)));
-    hi1 = _mm_or_si128(hi1, _mm_and_si128(mask, _mm_load_si128(precomp + 1)));
-    lo2 = _mm_or_si128(lo2, _mm_and_si128(mask, _mm_load_si128(precomp + 2)));
-    hi2 = _mm_or_si128(hi2, _mm_and_si128(mask, _mm_load_si128(precomp + 3)));
-    precomp += 2 * 2;
-  }
-  _mm_storeu_si128(dst + 0, lo1);
-  _mm_storeu_si128(dst + 1, hi1);
-  _mm_storeu_si128(dst + 2, lo2);
-  _mm_storeu_si128(dst + 3, hi2);
-}
-
 void ct_get3(__m128i* dst, const __m128i* precomp, int line_size, unsigned index) {
   __m128i lo1, hi1, lo2, hi2, lo3, hi3;
   lo1 = hi1 = lo2 = hi2 = lo3 = hi3 = _mm_setzero_si128();

--- a/src/cbmpc/crypto/base_ec_core.h
+++ b/src/cbmpc/crypto/base_ec_core.h
@@ -20,7 +20,6 @@ class booth_wnaf_t {
 };
 
 #ifdef __x86_64__
-void ct_get2(__m128i* dst, const __m128i* precomp, int line_size, unsigned index);
 void ct_get3(__m128i* dst, const __m128i* precomp, int line_size, unsigned index);
 #endif
 

--- a/src/cbmpc/crypto/base_rsa.cpp
+++ b/src/cbmpc/crypto/base_rsa.cpp
@@ -20,23 +20,6 @@ enum {
   part_qinv = 1 << 7,
 };
 
-static void_ptr *find_ptr(void_ptr buffer, void_ptr pointer) {
-  byte_ptr buf = byte_ptr(buffer);
-  for (;;) {
-    void_ptr *b = (void_ptr *)buf++;
-    if (pointer == *b) return b;
-  }
-  return nullptr;
-}
-
-static buf_t prepend_oid(hash_e hash_alg, mem_t data) {
-  mem_t oid = hash_alg_t::get(hash_alg).oid;
-  buf_t out(oid.size + data.size);
-  memmove(out.data(), oid.data, oid.size);
-  memmove(out.data() + oid.size, data.data, data.size);
-  return out;
-}
-
 // ------------------------------ rsa_pub_key_t -------------------------
 
 error_t rsa_pub_key_t::encrypt_raw(mem_t in, buf_t &out) const {

--- a/src/cbmpc/crypto/ec25519_core.cpp
+++ b/src/cbmpc/crypto/ec25519_core.cpp
@@ -1009,28 +1009,6 @@ extern "C" int ED25519_sign_with_scalar(uint8_t* out_sig, const uint8_t* message
   return 1;
 }
 
-extern "C" void ED25519_scalar_to_public(uint8_t out_public_key[32], const uint8_t scalar_bin[32]) {
-  uint8_t az[32];
-  for (int i = 0; i < 32; i++) az[i] = scalar_bin[31 - i];
-
-  bn_t az_bn = from_le_mod_q(mem_t(az, 32));
-  point_t A;
-  curve_t::mul_to_generator(az_bn, A);
-  to_bin(A, out_public_key);
-
-  OPENSSL_cleanse(az, sizeof(az));
-}
-
-extern "C" void ED25519_private_to_scalar(uint8_t out_scalar_bin[32], const uint8_t private_key[32]) {
-  uint8_t az[64];
-  hash_az(az, private_key);
-
-  bn_t scalar = from_le_mod_q(mem_t(az, 32));
-  scalar.to_bin(out_scalar_bin, 32);
-
-  OPENSSL_cleanse(az, sizeof(az));
-}
-
 }  // namespace coinbase::crypto::ec25519_core
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000

--- a/src/cbmpc/crypto/ec25519_core.h
+++ b/src/cbmpc/crypto/ec25519_core.h
@@ -35,6 +35,4 @@ int ED25519_sign(uint8_t* out_sig, const uint8_t* message, size_t message_len, c
                  const uint8_t private_key[32]);
 int ED25519_sign_with_scalar(uint8_t* out_sig, const uint8_t* message, size_t message_len, const uint8_t public_key[32],
                              const uint8_t private_key[32]);
-void ED25519_private_to_scalar(uint8_t out_scalar_bin[32], const uint8_t private_key[32]);
-void ED25519_scalar_to_public(uint8_t out_public_key[32], const uint8_t scalar_bin[32]);
 }

--- a/src/cbmpc/protocol/ot.h
+++ b/src/cbmpc/protocol/ot.h
@@ -259,7 +259,6 @@ struct ot_protocol_pvw_ctx_t {
 };
 
 }  // namespace coinbase::mpc
-
 namespace coinbase::crypto {
 template <>
 inline int get_bin_size(const mpc::h_matrix_256rows_t& matrix) {

--- a/tools/benchmark/bm_ot.cpp
+++ b/tools/benchmark/bm_ot.cpp
@@ -95,7 +95,7 @@ class FullOT2PBenchmark : public benchmark::Fixture {
   void SetUp(const ::benchmark::State& st) override {
     // Fix u = 256 (unused in these steps, but matching the prior test logic)
     m = static_cast<int>(st.range(0));
-    ot = std::make_unique<ot_protocol_pvw_ctx_t>(crypto::curve_secp256k1);
+    ot = std::make_unique<ot_protocol_pvw_ctx_t>();
     ot->base.sid = crypto::gen_random(16);
     curve = ot->base.curve;
     q = curve.order();


### PR DESCRIPTION
- Removes numerous unused functions and code paths across the crypto modules (base, rsa, ec, ed25519).
- Introduces input validation for deserializing containers (std::vector, bufs128_t) to guard against large allocation attacks.
- Fixes an integer overflow vulnerability in the scr_inv modular inverse implementation.
- Improves BN_CTX thread-local storage management by switching to scoped_ptr_t.
- Strengthens the mod_t::coprime check by catching exceptions for non-invertible elements.
- Adds a clear thread-safety warning to the main README.md.
- Adds comprehensive unit tests for the coprime and scr_inv logic.