### PR TITLE
build: Improve OpenSSL build process and fix on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,16 +86,16 @@ endif()
 
 include_directories(${SRC_DIR})
 
+add_subdirectory(src/cbmpc/core)
+add_subdirectory(src/cbmpc/crypto)
+add_subdirectory(src/cbmpc/zk)
+add_subdirectory(src/cbmpc/protocol)
+
 add_library(
   cbmpc STATIC $<TARGET_OBJECTS:cbmpc_core> $<TARGET_OBJECTS:cbmpc_crypto>
                $<TARGET_OBJECTS:cbmpc_zk> $<TARGET_OBJECTS:cbmpc_protocol>)
 
 link_openssl(cbmpc)
-
-add_subdirectory(src/cbmpc/core)
-add_subdirectory(src/cbmpc/crypto)
-add_subdirectory(src/cbmpc/zk)
-add_subdirectory(src/cbmpc/protocol)
 
 # ------------- Tests ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,36 @@ There are three build modes available:
 
 ### OpenSSL
 
-The library depends on OpenSSL. Therefore, the first step is to build the proper version of OpenSSL. The write permission to the `/usr/local/opt` may be required
+The library depends on a **custom build of OpenSSL 3.2.0** with specific modifications (see [External Dependencies](#external-dependencies)). You must build this custom version before compiling the library.
+
+**Quick Start:**
+```bash
+# Automatic detection of your platform
+make openssl
+
+# Or use platform-specific targets:
+make openssl-macos      # for x86_64
+make openssl-macos-m1   # for ARM64 (Apple Silicon)
+```
+
+**Manual Build:**
+```bash
+scripts/openssl/build-static-openssl-macos.sh      # for x86_64
+# or
+scripts/openssl/build-static-openssl-macos-m1.sh   # for ARM64
+```
+
+**Note:** These scripts install OpenSSL to `/usr/local/opt/openssl@3.2.0` and may require `sudo` permission.
+
+**Custom Install Location:**
+If you prefer a different installation path, you can set the `CBMPC_OPENSSL_ROOT` variable:
 
 ```bash
-scripts/openssl/build-static-openssl-macos.sh
-or
-scripts/openssl/build-static-openssl-macos-m1.sh
+# Option 1: Environment variable (before running cmake)
+export CBMPC_OPENSSL_ROOT=/your/custom/path
+
+# Option 2: CMake variable
+cmake -DCBMPC_OPENSSL_ROOT=/your/custom/path ...
 ```
 
 ### Compilers

--- a/cmake/openssl.cmake
+++ b/cmake/openssl.cmake
@@ -1,3 +1,16 @@
+# Link OpenSSL to a target
+#
+# This macro links the custom OpenSSL build to a CMake target.
+# The OpenSSL path can be customized via:
+#   1. CMake variable: -DCBMPC_OPENSSL_ROOT=/path/to/openssl
+#   2. Environment variable: export CBMPC_OPENSSL_ROOT=/path/to/openssl
+#   3. Default: /usr/local/opt/openssl@3.2.0
+#
+# To build the custom OpenSSL, run the appropriate script:
+#   - macOS (x86_64): scripts/openssl/build-static-openssl-macos.sh
+#   - macOS (ARM64):  scripts/openssl/build-static-openssl-macos-m1.sh
+#   - Linux:          scripts/openssl/build-static-openssl-linux.sh
+#
 macro(link_openssl TARGET_NAME)
   if(NOT DEFINED CBMPC_OPENSSL_ROOT)
     if(DEFINED ENV{CBMPC_OPENSSL_ROOT})
@@ -21,9 +34,8 @@ macro(link_openssl TARGET_NAME)
     return()
   endif()
 
-  if(NOT EXISTS "${_cbmpc_openssl_include}" OR NOT EXISTS "${_cbmpc_openssl_lib}")
-    message(FATAL_ERROR "OpenSSL not found at ${CBMPC_OPENSSL_ROOT}. Set CBMPC_OPENSSL_ROOT.")
-  endif()
+  # Note: Do not hard-fail on missing OpenSSL here to keep compatibility with
+  # external security workflows that may configure without building.
 
   target_include_directories(${TARGET_NAME} PUBLIC "${_cbmpc_openssl_include}")
   target_link_libraries(${TARGET_NAME} PUBLIC "${_cbmpc_openssl_lib}")

--- a/src/cbmpc/core/CMakeLists.txt
+++ b/src/cbmpc/core/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_library(cbmpc_core OBJECT "")
 
+# Link OpenSSL before precompiled headers to ensure headers are available
+link_openssl(cbmpc_core)
+
 target_precompile_headers(cbmpc_core PUBLIC "precompiled.h")
 
 target_sources(cbmpc_core PRIVATE

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,3 +1,4 @@
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_library(cbmpc_test_util STATIC ${SOURCES})
 target_include_directories(cbmpc_test_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+link_openssl(cbmpc_test_util)


### PR DESCRIPTION
This commit introduces several improvements to the build system, focusing on making the custom OpenSSL dependency easier to manage and fixing critical ordering issues in CMake.

### OpenSSL Build Improvements
The previous process for building the required custom OpenSSL was manual and error-prone. This change streamlines the entire experience.

### New make openssl Target
A new, platform-aware make openssl target has been added. It automatically detects the user's OS (macOS/Linux) and architecture (x86_64/ARM64) and runs the appropriate build script. This simplifies the setup instructions to a single command.

Customizable Install Path: The OpenSSL installation path was previously hardcoded. Now, users can specify a custom location by setting the CBMPC_OPENSSL_ROOT environment or CMake variable. This is crucial for environments where the user lacks write permissions to /usr/local/opt.

### CMake Fixes
Several logical errors in the CMake configuration have been corrected to ensure a more reliable and deterministic build.