### PR TITLE
refactor: Consolidate threshold DKG logic into key_share_mp_t

### DIFF
--- a/demos-go/cb-mpc-go/internal/cgobinding/eckeymp.cpp
+++ b/demos-go/cb-mpc-go/internal/cgobinding/eckeymp.cpp
@@ -136,8 +136,7 @@ int eckey_dkg_mp_threshold_dkg(job_mp_ref* job_ptr, ecurve_ref* curve_ref, cmem_
 
   // Allocate key share with RAII – will auto free on early return.
   std::unique_ptr<eckey::key_share_mp_t> key_share(new eckey::key_share_mp_t());
-  eckey::dkg_mp_threshold_t dkg_threshold;
-  error_t err = dkg_threshold.dkg(*job, *curve_ptr, sid_buf, *ac_obj, *quorum_set, *key_share);
+  error_t err = eckey::key_share_mp_t::threshold_dkg(*job, *curve_ptr, sid_buf, *ac_obj, *quorum_set, *key_share);
   if (err) {
     return err;  // unique_ptr cleans up
   }

--- a/src/cbmpc/protocol/ec_dkg.cpp
+++ b/src/cbmpc/protocol/ec_dkg.cpp
@@ -261,9 +261,9 @@ error_t key_share_mp_t::refresh(job_mp_t& job, buf_t& sid, const key_share_mp_t&
   return SUCCESS;
 }
 
-error_t dkg_mp_threshold_t::dkg_or_refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t ac,
-                                           const party_set_t& quorum_party_set, key_share_mp_t& key,
-                                           key_share_mp_t& new_key, bool is_refresh) {
+error_t key_share_mp_t::threshold_dkg_or_refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid,
+                                                 const crypto::ss::ac_t ac, const party_set_t& quorum_party_set,
+                                                 key_share_mp_t& key, key_share_mp_t& new_key, bool is_refresh) {
   error_t rv = UNINITIALIZED_ERROR;
 
   const auto& G = curve.generator();
@@ -451,17 +451,18 @@ error_t dkg_mp_threshold_t::dkg_or_refresh(job_mp_t& job, const ecurve_t& curve,
   return SUCCESS;
 }
 
-error_t dkg_mp_threshold_t::dkg(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t ac,
-                                const party_set_t& quorum_party_set, key_share_mp_t& key) {
+error_t key_share_mp_t::threshold_dkg(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t ac,
+                                      const party_set_t& quorum_party_set, key_share_mp_t& key) {
   key_share_mp_t dummy_new_key;
   bool is_refresh = false;
-  return dkg_or_refresh(job, curve, sid, ac, quorum_party_set, key, dummy_new_key, is_refresh);
+  return threshold_dkg_or_refresh(job, curve, sid, ac, quorum_party_set, key, dummy_new_key, is_refresh);
 }
 
-error_t dkg_mp_threshold_t::refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t ac,
-                                    const party_set_t& quorum_party_set, key_share_mp_t& key, key_share_mp_t& new_key) {
+error_t key_share_mp_t::threshold_refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t ac,
+                                          const party_set_t& quorum_party_set, key_share_mp_t& key,
+                                          key_share_mp_t& new_key) {
   bool is_refresh = true;
-  return dkg_or_refresh(job, curve, sid, ac, quorum_party_set, key, new_key, is_refresh);
+  return threshold_dkg_or_refresh(job, curve, sid, ac, quorum_party_set, key, new_key, is_refresh);
 }
 
 error_t key_share_mp_t::reconstruct_additive_share(const mod_t& q, const node_t* node,

--- a/src/cbmpc/protocol/ec_dkg.h
+++ b/src/cbmpc/protocol/ec_dkg.h
@@ -62,7 +62,7 @@ struct key_share_mp_t {
 
   /**
    * @specs:
-   * - ec-dkg-spec | EC-Refresh-MP
+   * - ec-dkg-spec | EC-DKG-MP
    */
   static error_t dkg(job_mp_t& job, ecurve_t curve, key_share_mp_t& key, buf_t& sid);
 
@@ -82,9 +82,8 @@ struct key_share_mp_t {
   error_t reconstruct_pub_additive_shares(const crypto::ss::node_t* node, const std::set<crypto::pname_t>& quorum_names,
                                           const crypto::pname_t target, ecc_point_t& pub_additive_shares,
                                           bool& is_in_quorum) const;
-};
 
-struct dkg_mp_threshold_t {
+ public:
   /**
    * @specs:
    * - ec-dkg-spec | EC-DKG-Threshold-MP
@@ -97,21 +96,21 @@ struct dkg_mp_threshold_t {
    * In the future, we are planning on adding a VSS implementation that will make it easier to implement a threshold DKG
    * with only a subset of the parties online.
    */
-  static error_t dkg(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t,
-                     const party_set_t& quorum_party_set, key_share_mp_t& key);
+  static error_t threshold_dkg(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t,
+                               const party_set_t& quorum_party_set, key_share_mp_t& key);
   /**
    * @specs:
    * - ec-dkg-spec | EC-Refresh-Threshold-MP
    * @notes:
    * - See `dkg` for notes.
    */
-  static error_t refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t,
-                         const party_set_t& quorum_party_set, key_share_mp_t& key, key_share_mp_t& new_key);
+  static error_t threshold_refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t,
+                                   const party_set_t& quorum_party_set, key_share_mp_t& key, key_share_mp_t& new_key);
 
  private:
-  static error_t dkg_or_refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t,
-                                const party_set_t& quorum_party_set, key_share_mp_t& key, key_share_mp_t& new_key,
-                                bool is_refresh);
+  static error_t threshold_dkg_or_refresh(job_mp_t& job, const ecurve_t& curve, buf_t& sid, const crypto::ss::ac_t,
+                                          const party_set_t& quorum_party_set, key_share_mp_t& key,
+                                          key_share_mp_t& new_key, bool is_refresh);
 };
 
 }  // namespace coinbase::mpc::eckey

--- a/src/cbmpc/protocol/ecdsa_mp.cpp
+++ b/src/cbmpc/protocol/ecdsa_mp.cpp
@@ -26,6 +26,16 @@ error_t refresh(job_mp_t& job, buf_t& sid, key_t& key, key_t& new_key) {
   return eckey::key_share_mp_t::refresh(job, sid, key, new_key);
 }
 
+error_t threshold_dkg(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                      const party_set_t& quorum_party_set, key_t& key) {
+  return eckey::key_share_mp_t::threshold_dkg(job, curve, sid, ac, quorum_party_set, key);
+}
+
+error_t threshold_refresh(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                          const party_set_t& quorum_party_set, key_t& key, key_t& new_key) {
+  return eckey::key_share_mp_t::threshold_refresh(job, curve, sid, ac, quorum_party_set, key, new_key);
+}
+
 error_t sign(job_mp_t& job, key_t& key, mem_t msg, const party_idx_t sig_receiver,
              const std::vector<std::vector<int>>& ot_role_map, buf_t& sig) {
   error_t rv = UNINITIALIZED_ERROR;

--- a/src/cbmpc/protocol/ecdsa_mp.h
+++ b/src/cbmpc/protocol/ecdsa_mp.h
@@ -33,6 +33,20 @@ error_t refresh(job_mp_t& job, buf_t& sid, key_t& key, key_t& new_key);
 
 /**
  * @specs:
+ * - ec-dkg-spec | EC-DKG-Threshold-MP
+ */
+error_t threshold_dkg(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                      const party_set_t& quorum_party_set, key_t& key);
+
+/**
+ * @specs:
+ * - ec-dkg-spec | EC-Refresh-Threshold-MP
+ */
+error_t threshold_refresh(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                          const party_set_t& quorum_party_set, key_t& key, key_t& new_key);
+
+/**
+ * @specs:
  * - ecdsa-mpc-spec | ECDSA-MPC-Sign-MP
  * @notes:
  * - This function runs base OT internally which is not efficient and is only done for ease of use.

--- a/src/cbmpc/protocol/schnorr_mp.cpp
+++ b/src/cbmpc/protocol/schnorr_mp.cpp
@@ -18,6 +18,24 @@ using namespace coinbase::mpc;
 
 namespace coinbase::mpc::schnorrmp {
 
+error_t dkg(job_mp_t& job, ecurve_t curve, key_t& key, buf_t& sid) {
+  return eckey::key_share_mp_t::dkg(job, curve, key, sid);
+}
+
+error_t refresh(job_mp_t& job, buf_t& sid, key_t& key, key_t& new_key) {
+  return eckey::key_share_mp_t::refresh(job, sid, key, new_key);
+}
+
+error_t threshold_dkg(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                      const party_set_t& quorum_party_set, key_t& key) {
+  return eckey::key_share_mp_t::threshold_dkg(job, curve, sid, ac, quorum_party_set, key);
+}
+
+error_t threshold_refresh(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                          const party_set_t& quorum_party_set, key_t& key, key_t& new_key) {
+  return eckey::key_share_mp_t::threshold_refresh(job, curve, sid, ac, quorum_party_set, key, new_key);
+}
+
 static bn_t calc_eddsa_HRAM(const ecc_point_t& R, const ecc_point_t& Q, mem_t in) {
   buf_t HRAM_buf = crypto::sha512_t::hash(R, Q.to_compressed_bin(), in);
   bn_t HRAM = bn_t::from_bin(HRAM_buf.rev()) % crypto::curve_ed25519.order();

--- a/src/cbmpc/protocol/schnorr_mp.h
+++ b/src/cbmpc/protocol/schnorr_mp.h
@@ -17,6 +17,32 @@ enum class variant_e {
 
 /**
  * @specs:
+ * - ec-dkg-spec | EC-DKG-MP
+ */
+error_t dkg(job_mp_t& job, ecurve_t curve, key_t& key, buf_t& sid);
+
+/**
+ * @specs:
+ * - ec-dkg-spec | EC-Refresh-MP
+ */
+error_t refresh(job_mp_t& job, buf_t& sid, key_t& key, key_t& new_key);
+
+/**
+ * @specs:
+ * - ec-dkg-spec | EC-DKG-Threshold-MP
+ */
+error_t threshold_dkg(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                      const party_set_t& quorum_party_set, key_t& key);
+
+/**
+ * @specs:
+ * - ec-dkg-spec | EC-Refresh-Threshold-MP
+ */
+error_t threshold_refresh(job_mp_t& job, ecurve_t curve, buf_t& sid, const crypto::ss::ac_t ac,
+                          const party_set_t& quorum_party_set, key_t& key, key_t& new_key);
+
+/**
+ * @specs:
  * - schnorr-spec | Schnorr-MPC-Sign-MP
  */
 error_t sign_batch(job_mp_t& job, key_t& key, const std::vector<mem_t>& msgs, party_idx_t sig_receiver,

--- a/tests/unit/protocol/test_ec_dkg.cpp
+++ b/tests/unit/protocol/test_ec_dkg.cpp
@@ -36,8 +36,8 @@ static void RunDkgAndAdditiveShareTest(crypto::ss::node_t* root_node, const std:
   buf_t sid_dkg = crypto::gen_random(16);
   mpc_runner_t all_parties_runner(pnames);
   all_parties_runner.run_mpc([&](mpc::job_mp_t& job) {
-    coinbase::mpc::eckey::dkg_mp_threshold_t dkg_threshold;
-    ASSERT_OK(dkg_threshold.dkg(job, curve, sid_dkg, ac, quorum_party_set, keyshares[job.get_party_idx()]));
+    ASSERT_OK(coinbase::mpc::eckey::key_share_mp_t::threshold_dkg(job, curve, sid_dkg, ac, quorum_party_set,
+                                                                  keyshares[job.get_party_idx()]));
   });
 
   // Basic key consistency

--- a/tests/unit/protocol/test_ecdsa_mp.cpp
+++ b/tests/unit/protocol/test_ecdsa_mp.cpp
@@ -238,8 +238,8 @@ TEST(ECDSAMPCThreshold, DKG) {
   // DKG is an n-party protocol
   mpc_runner_t all_parties_runner(pnames);
   all_parties_runner.run_mpc([&curve, &keyshares, &quorum_party_set, &ac, &sid_dkg](mpc::job_mp_t& job) {
-    eckey::dkg_mp_threshold_t dkg_threshold;
-    EXPECT_OK(dkg_threshold.dkg(job, curve, sid_dkg, ac, quorum_party_set, keyshares[job.get_party_idx()]));
+    EXPECT_OK(eckey::key_share_mp_t::threshold_dkg(job, curve, sid_dkg, ac, quorum_party_set,
+                                                   keyshares[job.get_party_idx()]));
   });
 
   for (int i = 0; i < n; i++) {
@@ -268,9 +268,9 @@ TEST(ECDSAMPCThreshold, DKG) {
 
   // Refresh is an n-party protocol
   all_parties_runner.run_mpc([&](mpc::job_mp_t& job) {
-    eckey::dkg_mp_threshold_t dkg_threshold;
-    ASSERT_OK(dkg_threshold.refresh(job, curve, sid_refresh, ac, quorum_party_set, keyshares[job.get_party_idx()],
-                                    new_keyshares[job.get_party_idx()]));
+    ASSERT_OK(eckey::key_share_mp_t::threshold_refresh(job, curve, sid_refresh, ac, quorum_party_set,
+                                                       keyshares[job.get_party_idx()],
+                                                       new_keyshares[job.get_party_idx()]));
   });
   ASSERT_EQ(sid_refresh.size(), 16);
   ASSERT_NE(sid_refresh, sid_dkg);


### PR DESCRIPTION
The static methods for threshold distributed key generation (DKG) and key refresh have been moved from the `dkg_mp_threshold_t` struct to become static methods of `key_share_mp_t`.

This refactoring simplifies the code by removing the unnecessary `dkg_mp_threshold_t` struct and centralizes key generation logic within the key share structure itself.

The functions were renamed to `threshold_dkg` and `threshold_refresh` for clarity. All call sites and protocol wrappers (`ecdsa_mp`, `schnorr_mp`) have been updated to use the new API.