### PR TITLE
fix: Prevent Out-of-Bounds read in PVE

### DIFF
--- a/src/cbmpc/core/buf.h
+++ b/src/cbmpc/core/buf.h
@@ -70,6 +70,13 @@ struct mem_t {
   uint8_t operator[](int index) const { return data[index]; }
   uint8_t& operator[](int index) { return data[index]; }
 
+  /**
+   * @warning:
+   * - These helpers perform no bounds checks. Callers must ensure:
+   *   0 ≤ offset ≤ this->size and 0 ≤ len ≤ (this->size - offset).
+   * - Misuse can create invalid views and cause OOB access in downstream operations.
+   * - Example: taking/skipping fixed sizes requires the source buffer to be long enough.
+   */
   mem_t range(int offset, int size) const { return mem_t(data + offset, size); }
   mem_t skip(int offset) const { return range(offset, size - offset); }
   mem_t take(int size) const { return range(0, size); }
@@ -136,6 +143,13 @@ class buf_t {
   cmem_t to_cmem() const { return mem_t(*this).to_cmem(); }
   static buf_t from_cmem(cmem_t cmem);
 
+  /**
+   * @warning:
+   * - These helpers perform no bounds checks. Callers must ensure:
+   *   0 ≤ offset ≤ size() and 0 ≤ len ≤ (size() - offset).
+   * - Misuse can create invalid views and cause OOB access in downstream operations.
+   * - Example: taking/skipping fixed sizes requires the source buffer to be long enough.
+   */
   mem_t range(int offset, int size) const { return mem_t(data() + offset, size); }
   mem_t skip(int offset) const { return range(offset, size() - offset); }
   mem_t take(int size) const { return range(0, size); }

--- a/src/cbmpc/protocol/pve_ac.cpp
+++ b/src/cbmpc/protocol/pve_ac.cpp
@@ -168,6 +168,7 @@ error_t ec_pve_ac_t::verify(const ss::ac_t& ac, const pks_t& ac_pks, const std::
     } else {
       c1[i] = row.c;
       quorum_c1[i] = row.quorum_c;
+      if (row.r.size() != 32) return coinbase::error(E_CRYPTO);
       mem_t r0_1 = row.r.take(16);
       mem_t r0_2 = row.r.skip(16);
       encrypt_row0(ac, ac_pks, L, curve, r0_1, r0_2, batch_size, xb, c0[i], quorum_c0[i]);
@@ -261,6 +262,7 @@ error_t ec_pve_ac_t::aggregate_to_restore_row(const ss::ac_t& ac, int row_index,
     seed = decrypted_data;
   } else {
     x_bin = decrypted_data;
+    if (row.r.size() != 32) return coinbase::error(E_CRYPTO);
     seed = row.r.take(16);
   }
 

--- a/src/cbmpc/protocol/pve_batch.cpp
+++ b/src/cbmpc/protocol/pve_batch.cpp
@@ -107,6 +107,7 @@ error_t ec_pve_batch_t::verify(const void* ek, const std::vector<ecc_point_t>& Q
     } else {
       c1[i] = rows[i].c;
 
+      if (rows[i].r.size() != 32) return coinbase::error(E_CRYPTO);
       crypto::drbg_aes_ctr_t drbg01(rows[i].r.take(16));
       buf_t x0_source_bin = drbg01.gen(n * (curve_size + coinbase::bits_to_bytes(SEC_P_STAT)));
       xi = bn_t::vector_from_bin(x0_source_bin, n, curve_size + coinbase::bits_to_bytes(SEC_P_STAT), q);
@@ -149,6 +150,7 @@ error_t ec_pve_batch_t::restore_from_decrypted(int row_index, mem_t decrypted_x_
     r01 = decrypted_x_buf;
   } else {
     x1_bin = decrypted_x_buf;
+    if (rows[row_index].r.size() != 32) return coinbase::error(E_CRYPTO);
     r01 = rows[row_index].r.take(16);
   }
 


### PR DESCRIPTION
Added size checks in the PVE AC and Batch protocols to ensure the `r` buffer is 32 bytes before being sliced. A malformed message with a shorter buffer would previously cause an out-of-bounds read via `take()` or `skip()`, leading to a crash.

This change improves the robustness of buffer handling by validating the buffer's length. To further enhance clarity, helpful comments were added to the buffer helpers in `buf.h` to explicitly define the bounds-checking contract.