### PR TITLE
chore: Enhance protocol validation and link to specs

### DIFF
--- a/src/cbmpc/protocol/ec_dkg.cpp
+++ b/src/cbmpc/protocol/ec_dkg.cpp
@@ -437,6 +437,10 @@ error_t key_share_mp_t::threshold_dkg_or_refresh(job_mp_t& job, const ecurve_t& 
       crypto::vartime_scope_t vartime_scope;
       new_key.Qis[job.get_name(j)] += Qis[job.get_name(j)];
     }
+    ecc_point_t reconstructed_Q;
+    if (rv = ac.reconstruct_exponent(new_key.Qis, reconstructed_Q))
+      return coinbase::error(rv, "Failed to reconstruct exponent for new_key");
+    if (reconstructed_Q != key.Q) return coinbase::error(E_CRYPTO, "key.Q mismatch");
     new_key.party_name = job.get_name(i);
   } else {
     key.x_share = x_i;

--- a/src/cbmpc/protocol/pve_ac.cpp
+++ b/src/cbmpc/protocol/pve_ac.cpp
@@ -138,10 +138,10 @@ error_t ec_pve_ac_t::verify(const ss::ac_t& ac, const pks_t& ac_pks, const std::
   const auto& G = curve.generator();
   if (Q.size() != this->Q.size()) return coinbase::error(E_CRYPTO);
   for (int i = 0; i < batch_size; i++) {
-    if (Q[i] != this->Q[i]) return coinbase::error(E_CRYPTO);
+    if (rv = curve.check(Q[i])) return coinbase::error(rv, "ec_pve_ac_t::verify: check Q[i] failed");
   }
-
   if (Q != this->Q) return coinbase::error(E_CRYPTO);
+
   buf_t L = crypto::sha256_t::hash(label, Q);
   if (L != this->L) return coinbase::error(E_CRYPTO);
 


### PR DESCRIPTION
This commit strengthens security checks in PVE and DKG protocols and adds traceability by linking KEM/DEM functions to the `basic-primitives-spec`.

* PVE: Adds explicit point-on-curve checks in `pve_ac.cpp` and `pve_batch.cpp` to prevent invalid-curve attacks.
* DKG: Adds a public key reconstruction check in `ec_dkg.cpp` to verify the new shares match the original group key.
* PVE Batch: Validates the DRBG seed length and refactors RO hashing to use the generic `bitlen(SEC_P_COM)` instead of a hardcoded `bitlen128()`.
* PKI: Adds `@specs` tags to `seal`, `open`, `encapsulate`, and `decapsulate` in `base_pki.h` and renames `pkR` to `pub_key` for clarity.