### PR TITLE
feat: Add constant-time curve operations and enhancements

### DIFF
--- a/src/cbmpc/crypto/base_ecc_secp256k1.h
+++ b/src/cbmpc/crypto/base_ecc_secp256k1.h
@@ -24,6 +24,7 @@ class ecurve_secp256k1_t final : public ecurve_interface_t {
   void invert_point(ecc_point_t& P) const override;
   void add(const ecc_point_t& P1, const ecc_point_t& P2, ecc_point_t& R) const override;
   void add_consttime(const ecc_point_t& P1, const ecc_point_t& P2, ecc_point_t& R) const override;
+  ct_add_support_e ct_add_support() const override { return ct_add_support_e::Conditional; }
   void mul(const ecc_point_t& P, const bn_t& x, ecc_point_t& R) const override;
   void mul_vartime(const ecc_point_t& P, const bn_t& x, ecc_point_t& R) const override;
   void mul_to_generator(const bn_t& val, ecc_point_t& P) const override;

--- a/src/cbmpc/crypto/base_eddsa.h
+++ b/src/cbmpc/crypto/base_eddsa.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "base_ecc.h"
 #include "ec25519_core.h"
 
 namespace coinbase::crypto {
@@ -33,6 +34,7 @@ class ecurve_ed_t final : public ecurve_interface_t {
   void set_infinity(ecc_point_t& P) const override;
   void add(const ecc_point_t& P1, const ecc_point_t& P2, ecc_point_t& R) const override;
   void add_consttime(const ecc_point_t& P1, const ecc_point_t& P2, ecc_point_t& R) const override;
+  ct_add_support_e ct_add_support() const override { return ct_add_support_e::Full; }
   void mul(const ecc_point_t& P, const bn_t& x, ecc_point_t& R) const override;
   void mul_vartime(const ecc_point_t& P, const bn_t& x, ecc_point_t& R) const override;
   int to_compressed_bin(const ecc_point_t& P, byte_ptr out) const override;

--- a/src/cbmpc/crypto/base_paillier.cpp
+++ b/src/cbmpc/crypto/base_paillier.cpp
@@ -237,6 +237,19 @@ error_t paillier_t::verify_cipher(const mod_t& N, const mod_t& NN, const bn_t& c
   if (!mod_t::coprime(cipher, N)) return coinbase::error(E_CRYPTO);
   return SUCCESS;
 }
+// If the private key is present, we return a single uniform sample in Z_N,
+// which lands in Z_N^* with overwhelming probability; otherwise we resample
+// until gcd(sample, N) == 1.
+bn_t paillier_t::rand_N_star() const {
+  if (has_private) {
+    return bn_t::rand(N);
+  }
+  bn_t r;
+  do {
+    r = bn_t::rand(N);
+  } while (!mod_t::coprime(r, N));
+  return r;
+}
 
 error_t paillier_t::batch_verify_ciphers(const bn_t* ciphers, int n) const {
   if (n == 0) return SUCCESS;

--- a/src/cbmpc/crypto/base_paillier.h
+++ b/src/cbmpc/crypto/base_paillier.h
@@ -38,6 +38,8 @@ class paillier_t {
   bn_t encrypt(const bn_t& src) const;
   bn_t encrypt(const bn_t& src, const bn_t& rand) const;
 
+  bn_t rand_N_star() const;
+
   /**
    * @specs:
    * - basic-primitives-spec | Paillier-Decrypt-1P

--- a/src/cbmpc/protocol/ecdsa_2p.cpp
+++ b/src/cbmpc/protocol/ecdsa_2p.cpp
@@ -231,9 +231,7 @@ error_t sign_batch_impl(job_2p_t& job, buf_t& sid, const key_t& key, const std::
 
   std::vector<bn_t> m(n_sigs);
   for (int i = 0; i < n_sigs; i++) {
-    mem_t bin = msgs[i];
-    bin.size = std::min(bin.size, curve.size());
-    m[i] = bn_t::from_bin(bin);
+    m[i] = curve_msg_to_bn(msgs[i], curve);
   }
 
   if (sid.empty())

--- a/src/cbmpc/protocol/ecdsa_mp.cpp
+++ b/src/cbmpc/protocol/ecdsa_mp.cpp
@@ -408,9 +408,7 @@ error_t sign(job_mp_t& job, key_t& key, mem_t msg, const party_idx_t sig_receive
   if (W_eRHO_K != Z_eRHO_K.R) return coinbase::error(E_CRYPTO);
   if (W_eRHO_X != Z_eRHO_X.R) return coinbase::error(E_CRYPTO);
 
-  mem_t data_to_sign = msg;
-  if (data_to_sign.size > curve.size()) data_to_sign.size = curve.size();
-  bn_t m = bn_t::from_bin(data_to_sign);
+  bn_t m = curve_msg_to_bn(msg, curve);
   bn_t r_rho_x, rho_m, r_eR_RHO_X, r_eR_RHO_M, r_eB;
   auto beta = job.uniform_msg<bn_t>();
   MODULO(q) {

--- a/src/cbmpc/protocol/ot.cpp
+++ b/src/cbmpc/protocol/ot.cpp
@@ -63,14 +63,14 @@ error_t base_ot_protocol_pvw_ctx_t::step2_S2R(const std::vector<buf_t>& x0, cons
 
     bn_t s0 = bn_t::rand(q);
     bn_t t0 = bn_t::rand(q);
-    U0[i] = curve.mul_add(s0, H0, t0);                           // U0[i] = s0 * G[0] + t0 * H[0];
-    ecc_point_t X = extended_ec_mul_add_ct(s0, A[i], t0, B[i]);  // X     = s0 * A[i] + t0 * B[i];
+    U0[i] = curve.mul_add(s0, H0, t0);                              // U0[i] = s0 * G[0] + t0 * H[0];
+    ecc_point_t X = ecc_point_t::weighted_sum(s0, A[i], t0, B[i]);  // X     = s0 * A[i] + t0 * B[i];
     V0[i] = crypto::ro::hash_string(X).bitlen(l) ^ x0[i];
 
     bn_t s1 = bn_t::rand(q);
     bn_t t1 = bn_t::rand(q);
-    U1[i] = extended_ec_mul_add_ct(s1, G1, t1, H1);  // U1[i] = s1 * G[1] + t1 * H[1];
-    X = extended_ec_mul_add_ct(s1, A[i], t1, B[i]);  // X     = s1 * A[i] + t1 * B[i];
+    U1[i] = ecc_point_t::weighted_sum(s1, G1, t1, H1);  // U1[i] = s1 * G[1] + t1 * H[1];
+    X = ecc_point_t::weighted_sum(s1, A[i], t1, B[i]);  // X     = s1 * A[i] + t1 * B[i];
     V1[i] = crypto::ro::hash_string(X).bitlen(l) ^ x1[i];
   }
 

--- a/src/cbmpc/protocol/util.h
+++ b/src/cbmpc/protocol/util.h
@@ -61,3 +61,8 @@ auto map_args_to_tuple(F f, Args&&... args) {
   std::tuple<Args...> tup(std::forward<Args>(args)...);
   return map_args_to_tuple_impl(f, tup, std::index_sequence_for<Args...>{});
 }
+
+inline bn_t curve_msg_to_bn(mem_t msg, const ecurve_t& curve) {
+  if (msg.size > curve.size()) msg.size = curve.size();
+  return bn_t::from_bin(msg);
+}

--- a/src/cbmpc/zk/zk_elgamal_com.cpp
+++ b/src/cbmpc/zk/zk_elgamal_com.cpp
@@ -195,7 +195,7 @@ void uc_elgamal_com_mult_private_scalar_t::prove(const ecc_point_t& Q, const elg
           r1[i] = bn_t::rand(q);
           r2[i] = bn_t::rand(q);
           A1_tag[i] = curve.mul_add(r2[i], A1, r1[i]);
-          A2_tag[i] = crypto::extended_ec_mul_add_ct(r1[i], A2, r2[i], Q);
+          A2_tag[i] = ecc_point_t::weighted_sum(r1[i], A2, r2[i], Q);
         }
         common_hash = crypto::ro::hash_string(Q, A, B, A1_tag, A2_tag, session_id, aux).bitlen(2 * SEC_P_COM);
       },

--- a/src/cbmpc/zk/zk_paillier.cpp
+++ b/src/cbmpc/zk/zk_paillier.cpp
@@ -129,7 +129,7 @@ void paillier_zero_t::prove(const crypto::paillier_t& paillier, const bn_t& c, c
           .bitlen(param::padded_log_alpha * param::t);  // use only 13 bits for each ei
 
   for (int i = 0; i < param::t; i++) {
-    bn_t ei = param::get_13_bits(e, i);
+    bn_t ei = param::get_log_alpha_bits(e, i);
     MODULO(N) z[i] = rho[i] * r.pow(ei);
   }
 }
@@ -161,7 +161,7 @@ error_t paillier_zero_t::verify(const crypto::paillier_t& paillier, const bn_t& 
   bn_t z_prod = 1;
   for (int i = 0; i < param::t; i++) {
     MODULO(N) z_prod *= z[i];
-    bn_t ei = param::get_13_bits(e, i);
+    bn_t ei = param::get_log_alpha_bits(e, i);
     MODULO(NN) a[i] = z[i].pow(N) * d.pow(ei);
   }
   if (z_prod == 0 || !mod_t::coprime(z_prod, N)) return coinbase::error(E_CRYPTO);
@@ -270,7 +270,7 @@ void two_paillier_equal_t::prove(const mod_t& q, const crypto::paillier_t& P0, c
           .bitlen(param::t * param::padded_log_alpha);  // only 13 bits are used for each ei
 
   for (int i = 0; i < param::t; i++) {
-    bn_t ei = param::get_13_bits(e, i);
+    bn_t ei = param::get_log_alpha_bits(e, i);
     d[i] = ei * x + tau[i];
     MODULO(N0) r0_hat[i] = r0.pow(ei) * R0_tilde[i];
     MODULO(N1) r1_hat[i] = r1.pow(ei) * R1_tilde[i];
@@ -331,7 +331,7 @@ error_t two_paillier_equal_t::verify(const mod_t& q, const crypto::paillier_t& P
   for (int i = 0; i < param::t; i++) {
     if (rv = coinbase::crypto::check_right_open_range(0, d[i], q_with_slack)) return rv;
 
-    bn_t ei = param::get_13_bits(e, i);
+    bn_t ei = param::get_log_alpha_bits(e, i);
 
     if (r0_hat[i] <= 0) return coinbase::error(E_CRYPTO);
     if (r1_hat[i] <= 0) return coinbase::error(E_CRYPTO);
@@ -399,7 +399,7 @@ error_t two_paillier_equal_interactive_t::prover_msg2(const crypto::paillier_t& 
   const mod_t& N1 = P1.get_N();
 
   for (int i = 0; i < param::t; i++) {
-    bn_t ei = param::get_13_bits(challenge_msg.e, i);
+    bn_t ei = param::get_log_alpha_bits(challenge_msg.e, i);
     msg2.d[i] = ei * x + tau[i];
     MODULO(N0) msg2.r0_hat[i] = r0.pow(ei) * R0_tilde[i];
     MODULO(N1) msg2.r1_hat[i] = r1.pow(ei) * R1_tilde[i];
@@ -472,7 +472,7 @@ error_t two_paillier_equal_interactive_t::verify(const mod_t& q, const crypto::p
     MODULO(N0) H0_test *= msg2.r0_hat[i] * msg2.c0_tilde[i];
     MODULO(N1) H1_test *= msg2.r1_hat[i] * msg2.c1_tilde[i];
 
-    bn_t ei = param::get_13_bits(e, i);
+    bn_t ei = param::get_log_alpha_bits(e, i);
     bn_t t0, t1;
     MODULO(NN0) t0 = c0.pow(ei) * msg2.c0_tilde[i];
     MODULO(NN1) t1 = c1.pow(ei) * msg2.c1_tilde[i];

--- a/src/cbmpc/zk/zk_util.h
+++ b/src/cbmpc/zk/zk_util.h
@@ -6,16 +6,33 @@ namespace coinbase::zk {
 
 enum class zk_flag { unverified, verified, skip };
 
+// read-only memory buffer of short integers
+// for example, if only 13 bits used from each 16 bits block (uint16_t),
+// then 16 bits are used for simpler splitting using uint16_t
+template <int item_bitlen>
+class uint_mem_array_t {
+ private:
+  const_byte_ptr ptr;
+
+ public:
+  uint_mem_array_t(mem_t mem) : ptr(mem.data) {}
+  unsigned operator[](int index) const {
+    constexpr int byte_len = (item_bitlen + CHAR_BIT - 1) / CHAR_BIT;
+    static_assert(byte_len == 2, "unsupported bitlen");
+    constexpr unsigned mask = unsigned(-1) >> ((sizeof(unsigned) * CHAR_BIT) - item_bitlen);
+    return coinbase::be_get_2(ptr + index * byte_len) & mask;
+  }
+};
+
 struct param_t {
   inline static constexpr int log_alpha = 13;
   inline static constexpr int padded_log_alpha = 16;  // rounded up multiple of 8 for byte alignment
   inline static constexpr int alpha = 1 << log_alpha;
   inline static constexpr int alpha_bits_mask = alpha - 1;
 
-  static uint16_t get_13_bits(mem_t e, int index) {
-    static_assert(log_alpha <= 16);  // We assume alpha bits can be stored in 16 bits.
-    uint16_t ei_tag = coinbase::be_get_2(e.data + index * 2);
-    return ei_tag & alpha_bits_mask;  // 13 bits
+  static uint16_t get_log_alpha_bits(mem_t e, int index) {
+    uint_mem_array_t<log_alpha> e_array(e);
+    return e_array[index];
   }
 };
 


### PR DESCRIPTION
This commit introduces constant-time elliptic curve operations and related improvements to the cryptographic primitives:

- Add ct_add_support enum and consttime_point_add_scope for managing constant-time point addition capabilities across different curve backends
- Implement weighted_sum() for secure multi-scalar multiplication
- Replace extended_ec_mul_add_ct with ecc_point_t::weighted_sum for consistency
- Add ct_add_support() implementation for Ed25519 (full support)
- Enhance Paillier with rand_N_star() for sampling Z_N^*
- Refactor ZK utilities: rename get_13_bits to get_log_alpha_bits and introduce uint_mem_array_t template for safer bit operations
- Update curve_msg_to_bn usage in ECDSA 2-party implementation