### PR TITLE
chore: general security and safety improvements

### DIFF
--- a/demos-cpp/basic_primitive/main.cpp
+++ b/demos-cpp/basic_primitive/main.cpp
@@ -22,7 +22,7 @@ mem_t hash_string()
   bn_t r = bn_t::rand(q);
   ecc_point_t G = c.generator();
 
-  return coinbase::crypto::ro::hash_string(c, G, r, 42).bitlen(32).take(32);
+  return coinbase::crypto::ro::hash_string(c, G, r, 42).bitlen(256).take(32);
 }
 
 ecc_point_t hash_curve()

--- a/src/cbmpc/core/buf128.h
+++ b/src/cbmpc/core/buf128.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cbmpc/core/error.h>
 #include <cbmpc/core/macros.h>
 
 #define ZERO128 (coinbase::buf128_t::zero())
@@ -85,8 +86,14 @@ struct buf128_t {
   buf128_t operator>>(unsigned n) const;
   buf128_t& operator>>=(unsigned n) { return *this = *this >> n; }
 
-  byte_t operator[](int index) const { return (byte_ptr(this))[index]; }
-  byte_t& operator[](int index) { return (byte_ptr(this))[index]; }
+  byte_t operator[](int index) const {
+    cb_assert(index >= 0 && index < 16);
+    return (byte_ptr(this))[index];
+  }
+  byte_t& operator[](int index) {
+    cb_assert(index >= 0 && index < 16);
+    return (byte_ptr(this))[index];
+  }
 
   void convert(coinbase::converter_t& converter);
 

--- a/src/cbmpc/core/buf256.cpp
+++ b/src/cbmpc/core/buf256.cpp
@@ -44,23 +44,15 @@ void buf256_t::save(byte_ptr dst) const {
   hi.save(dst + 16);
 }
 
-/**
- * @notes:
- * - The caller *must* ensure that 0 ≤ index < 256.
- * - This function intentionally does not perform this check to increase performance.
- */
 bool buf256_t::get_bit(int index) const {
+  cb_assert(index >= 0 && index < 256);
   int n = index / 64;
   index %= 64;
   return ((((const uint64_t*)(this))[n] >> index) & 1) != 0;
 }
 
-/**
- * @notes:
- * - The caller *must* ensure that 0 ≤ index < 256.
- * - This function intentionally does not perform this check to increase performance.
- */
 void buf256_t::set_bit(int index, bool value) {
+  cb_assert(index >= 0 && index < 256);
   int n = index / 64;
   index %= 64;
   uint64_t mask = uint64_t(1) << index;
@@ -71,9 +63,9 @@ void buf256_t::set_bit(int index, bool value) {
     ((uint64_t*)(this))[n] &= ~mask;
 }
 
-bool buf256_t::operator==(const buf256_t& src) const { return (src.lo == lo) && (src.hi == hi); }
+bool buf256_t::operator==(const buf256_t& src) const { return ((src.lo ^ lo) | (src.hi ^ hi)) == ZERO128; }
 
-bool buf256_t::operator!=(const buf256_t& src) const { return (src.lo != lo) || (src.hi != hi); }
+bool buf256_t::operator!=(const buf256_t& src) const { return ((src.lo ^ lo) | (src.hi ^ hi)) != ZERO128; }
 
 buf256_t buf256_t::operator~() const {
   buf256_t dst{};

--- a/src/cbmpc/core/log.h
+++ b/src/cbmpc/core/log.h
@@ -105,9 +105,6 @@ class log_frame_t {
   log_data_t params[max_param];
 };
 
-#define LOG(x) log_data_t(#x, x)
-#define LOGSTR(x) log_data_t(#x, x)
-
 struct dylog_disable_scope_t {
   dylog_disable_scope_t(bool enabled = false);
   ~dylog_disable_scope_t();

--- a/src/cbmpc/crypto/base.cpp
+++ b/src/cbmpc/crypto/base.cpp
@@ -129,20 +129,6 @@ coinbase::bits_t gen_random_bits(int count) {
   return out;
 }
 
-/**
- * Call through the next function which adds the check for equality of the sizes as well.
- */
-bool secure_equ(const_byte_ptr src1, const_byte_ptr src2, int size) {
-  byte_t x = 0;
-  while (size--) x |= (*src1++) ^ (*src2++);
-  return x == 0;
-}
-
-bool secure_equ(mem_t src1, mem_t src2) {
-  if (src1.size != src2.size) return false;
-  return secure_equ(src1.data, src2.data, src1.size);
-}
-
 int evp_cipher_ctx_t::update(mem_t in, byte_ptr out) const {
   if (in.size == 0) return 0;
 

--- a/src/cbmpc/crypto/base.h
+++ b/src/cbmpc/crypto/base.h
@@ -57,9 +57,6 @@ T gen_random_int() {
   return result;
 }
 
-bool secure_equ(mem_t src1, mem_t src2);
-bool secure_equ(const_byte_ptr src1, const_byte_ptr src2, int size);
-
 class evp_cipher_ctx_t {
  public:
   explicit evp_cipher_ctx_t() : ctx(EVP_CIPHER_CTX_new()) {}
@@ -89,11 +86,6 @@ class drbg_aes_ctr_t {
   drbg_aes_ctr_t(mem_t seed);
   ~drbg_aes_ctr_t() {}
 
-  /**
-   * @notes:
-   * - Note: this must be followed by a call to seed
-   */
-  void init();
   /**
    * @specs:
    * - basic-primitives-spec | drbg-init-1P
@@ -151,6 +143,9 @@ class drbg_aes_ctr_t {
 
  private:
   aes_ctr_t ctr;
+  // Note: this must be followed by a call to seed. We separate the initialization from the seeding to enable reseeding
+  // without reinitialization.
+  void init();
 };
 
 class aes_gcm_t {

--- a/src/cbmpc/crypto/drbg.cpp
+++ b/src/cbmpc/crypto/drbg.cpp
@@ -16,6 +16,7 @@ void drbg_aes_ctr_t::init() {
 drbg_aes_ctr_t::drbg_aes_ctr_t(mem_t s) { init(s); }
 
 void drbg_aes_ctr_t::init(mem_t s) {
+  cb_assert(coinbase::bytes_to_bits(s.size) >= SEC_P_COM && "DRBG requires SEC_P_COM bits of entropy");
   if (s.size == 32) {
     ctr.init(s.take(16), s.data + 16);
   } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,16 @@
 cmake_minimum_required(VERSION 3.16)
 
+# IMPORTANT: Set gtest options BEFORE adding googletest to the build
+# This prevents CRT/ABI mismatches that cause double-free errors under sanitizers
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE)
+
+# Disable Google Test's internal use of pthreads if it causes issues
+set(gtest_disable_pthreads
+    OFF
+    CACHE BOOL "" FORCE)
+
 if(USE_FETCH_CONTENT)
   include(FetchContent)
   FetchContent_Declare(
@@ -12,10 +23,25 @@ else()
                    ${CMAKE_CURRENT_BINARY_DIR}/googletest EXCLUDE_FROM_ALL)
 endif()
 
-# Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt
-    ON
-    CACHE BOOL "" FORCE)
+# Google Test must be built with default visibility to avoid ODR violations
+# when the main project uses -fvisibility=hidden.
+# This is critical for sanitizer builds where such violations cause crashes.
+if(TARGET gtest)
+  set_target_properties(gtest PROPERTIES CXX_VISIBILITY_PRESET default)
+  target_compile_options(gtest PRIVATE -fvisibility=default)
+endif()
+if(TARGET gtest_main)
+  set_target_properties(gtest_main PROPERTIES CXX_VISIBILITY_PRESET default)
+  target_compile_options(gtest_main PRIVATE -fvisibility=default)
+endif()
+if(TARGET gmock)
+  set_target_properties(gmock PROPERTIES CXX_VISIBILITY_PRESET default)
+  target_compile_options(gmock PRIVATE -fvisibility=default)
+endif()
+if(TARGET gmock_main)
+  set_target_properties(gmock_main PROPERTIES CXX_VISIBILITY_PRESET default)
+  target_compile_options(gmock_main PRIVATE -fvisibility=default)
+endif()
 
 enable_testing()
 

--- a/tests/unit/crypto/test_base.cpp
+++ b/tests/unit/crypto/test_base.cpp
@@ -59,19 +59,6 @@ TEST(BaseTest, TestGenRandomHelpers) {
   SUCCEED() << "Generated a random int: " << r_int;
 }
 
-TEST(BaseTest, TestSecureEqu) {
-  byte_t arr1[] = {0x01, 0x02, 0x03};
-  byte_t arr2[] = {0x01, 0x02, 0x03};
-  byte_t arr3[] = {0x01, 0x03, 0x03};
-
-  mem_t mem_a1(arr1, 3), mem_a2(arr2, 3), mem_a3(arr3, 3);
-
-  EXPECT_TRUE(secure_equ(mem_a1, mem_a2));
-  EXPECT_FALSE(secure_equ(mem_a1, mem_a3));
-  EXPECT_TRUE(secure_equ(arr1, arr2, 3));
-  EXPECT_FALSE(secure_equ(arr2, arr3, 3));
-}
-
 TEST(BaseTest, TestAES_CTR) {
   buf_t key = bn_t(0x00).to_bin(16);
   buf_t iv = bn_t(0x01).to_bin(16);
@@ -84,11 +71,9 @@ TEST(BaseTest, TestAES_CTR) {
 }
 
 TEST(BaseTest, TestDRBG) {
+  // Initialize and generate some data
   buf_t seed = bn_t(0xAB).to_bin(32);
   drbg_aes_ctr_t drbg(seed);
-
-  // Initialize and generate some data
-  drbg.init();
   buf_t random_data = drbg.gen(16);
   EXPECT_EQ(random_data.size(), 16);
 

--- a/tests/utils/local_network/channel.cpp
+++ b/tests/utils/local_network/channel.cpp
@@ -12,7 +12,7 @@ void test_message_buffer_t::free(test_message_buffer_t* buf) { ::free(buf); }
 std::atomic<int> test_channel_t::msg_counter = 0;
 bool test_channel_t::fuzzing = false;
 int test_channel_t::fuzzing_msg_counter = 0;
-crypto::drbg_aes_ctr_t test_channel_t::fuzzing_drbg = crypto::drbg_aes_ctr_t(buf_t());
+crypto::drbg_aes_ctr_t test_channel_t::fuzzing_drbg = crypto::drbg_aes_ctr_t(buf_t(16));
 
 void test_channel_t::send(test_channel_sync_t& sync, mem_t msg) {
   std::unique_lock lock(sync.mutex);


### PR DESCRIPTION
- Replace non-constant-time `memcmp` with XOR comparisons in `buf_t`, `mem_t`, and `u128/256` equality operators.
- Add bounds checking (`cb_assert`) to array operators (`[]`), bit accessors, and range helpers.
- Add integer overflow checks to buffer arithmetic.
- Enforce minimum entropy requirements for DRBG seeds.
- Remove standalone `secure_equ` helper as standard operators are now secure.