### PR TITLE
refactor: Move test-only ElGamal check functions to test file

### DIFF
--- a/src/cbmpc/crypto/elgamal.cpp
+++ b/src/cbmpc/crypto/elgamal.cpp
@@ -77,14 +77,4 @@ ec_elgamal_commitment_t ec_elgamal_commitment_t::rerand(const ecc_point_t& pub_k
   return UV;
 }
 
-bool ec_elgamal_commitment_t::check_zero(const bn_t& d) const  // d is the private key
-{
-  return R == d * L;
-}
-
-bool ec_elgamal_commitment_t::check_equ(const ec_elgamal_commitment_t& E1, const ec_elgamal_commitment_t& E2,
-                                        const bn_t& d) {
-  return (E1 - E2).check_zero(d);
-}
-
 }  // namespace coinbase::crypto

--- a/src/cbmpc/crypto/elgamal.h
+++ b/src/cbmpc/crypto/elgamal.h
@@ -81,8 +81,6 @@ class ec_elgamal_commitment_t {
    * - basic-primitives-spec | EC-ElGamal-Commit-ReRand-1P
    */
   void randomize(const bn_t& r, const ecc_point_t& pub_key);
-  bool check_zero(const bn_t& prv_key) const;
-  static bool check_equ(const ec_elgamal_commitment_t& E1, const ec_elgamal_commitment_t& E2, const bn_t& d);
   template <class T>
   void update_state(T& state) const {
     state.update(L);

--- a/tests/unit/crypto/test_elgamal.cpp
+++ b/tests/unit/crypto/test_elgamal.cpp
@@ -7,6 +7,13 @@ using namespace coinbase::crypto;
 
 namespace {
 
+// Helper functions for testing (moved from the library as they are test-only)
+bool check_zero(const ec_elgamal_commitment_t& E, const bn_t& d) { return E.R == d * E.L; }
+
+bool check_equ(const ec_elgamal_commitment_t& E1, const ec_elgamal_commitment_t& E2, const bn_t& d) {
+  return check_zero(E1 - E2, d);
+}
+
 class ElGamal : public testing::Test {
  protected:
   void SetUp() override {
@@ -47,16 +54,16 @@ TEST_F(ElGamal, API) {
   ec_elgamal_commitment_t A_plus_B_test =
       ec_elgamal_commitment_t::random_commit(P, a) + ec_elgamal_commitment_t::random_commit(P, b);
 
-  EXPECT_TRUE(ec_elgamal_commitment_t::check_equ(A_plus_B, A_plus_B_test, d));
-  EXPECT_TRUE(ec_elgamal_commitment_t::check_equ(A_plus_B_test, A_plus_b, d));
+  EXPECT_TRUE(check_equ(A_plus_B, A_plus_B_test, d));
+  EXPECT_TRUE(check_equ(A_plus_B_test, A_plus_b, d));
 
   ec_elgamal_commitment_t A1 = A;
   A1.randomize(P);
-  EXPECT_TRUE(ec_elgamal_commitment_t::check_equ(A, A1, d));
+  EXPECT_TRUE(check_equ(A, A1, d));
 
   ec_elgamal_commitment_t A_mul_c = c * A;
   ec_elgamal_commitment_t A_mul_c_test = ec_elgamal_commitment_t::random_commit(P, a * c);
-  EXPECT_TRUE(ec_elgamal_commitment_t::check_equ(A_mul_c_test, A_mul_c, d));
+  EXPECT_TRUE(check_equ(A_mul_c_test, A_mul_c, d));
 
   int p = 17;
   const mod_t& q = ec_elgamal_commitment_t::order(curve);
@@ -77,7 +84,7 @@ TEST_F(ElGamal, API) {
         bn_t r = bn_t::rand(q);
         X = X * r;
         X.randomize(P);
-        bool t = X.check_zero(d);
+        bool t = check_zero(X, d);
         EXPECT_EQ(t, test);
       }
     }


### PR DESCRIPTION
Remove `check_zero` and `check_equ` methods from `ec_elgamal_commitment_t` class as they are only used in tests. These functions are now local helpers in the test file, keeping the public API minimal.