### PR TITLE
fix: Correct benchmark function references, entropy seeds

### DIFF
--- a/tools/benchmark/bm_drbg.cpp
+++ b/tools/benchmark/bm_drbg.cpp
@@ -10,10 +10,13 @@ using namespace coinbase::crypto;
 static void DRBG_String(benchmark::State& state)
 {
   int u = state.range(0);
+  // DRBG requires at least SEC_P_COM bits (128 bits) of entropy in the seed.
+  // Use a fixed-size random seed generated once per benchmark run.
+  buf_t seed = gen_random(SEC_P_COM / 8);  // 16 bytes
   buf_t res;
   for (auto _ : state)
   {
-    res = ro::drbg_sample_string(mem_t("test"), u);
+    res = ro::drbg_sample_string(seed, u);
   }
 }
 BENCHMARK(DRBG_String)->Name("Crypto/DRBG/String")->RangeMultiplier(2)->Range(1 << 10, 1 << 18);
@@ -21,11 +24,12 @@ BENCHMARK(DRBG_String)->Name("Crypto/DRBG/String")->RangeMultiplier(2)->Range(1 
 static void DRBG_Number(benchmark::State& state)
 {
   int u = state.range(0);
+  buf_t seed = gen_random(SEC_P_COM / 8);  // 16-byte DRBG seed
   mod_t m(bn_t::generate_prime(u, false), /* multiplicative_dense */ true);
   bn_t res;
   for (auto _ : state)
   {
-    res = ro::drbg_sample_number(mem_t("test"), m);
+    res = ro::drbg_sample_number(seed, m);
   }
 }
 BENCHMARK(DRBG_Number)->Name("Crypto/DRBG/Number")->RangeMultiplier(2)->Range(1 << 8, 1 << 12);
@@ -33,10 +37,11 @@ BENCHMARK(DRBG_Number)->Name("Crypto/DRBG/Number")->RangeMultiplier(2)->Range(1 
 static void DRBG_Curve(benchmark::State& state)
 {
   ecurve_t curve = get_curve(state.range(0));
+  buf_t seed = gen_random(SEC_P_COM / 8);  // 16-byte DRBG seed
   ecc_point_t res;
   for (auto _ : state)
   {
-    res = ro::drbg_sample_curve(mem_t("test"), curve);
+    res = ro::drbg_sample_curve(seed, curve);
   }
 }
 BENCHMARK(DRBG_Curve)->Name("Crypto/DRBG/Curve")->Arg(3)->Arg(4);

--- a/tools/benchmark/bm_hash.cpp
+++ b/tools/benchmark/bm_hash.cpp
@@ -3,16 +3,16 @@
 #include <cbmpc/crypto/base.h>
 #include <cbmpc/crypto/ro.h>
 
-#define bit_len_lb 1 << 8
-#define bit_len_ub 1 << 12
-
 using namespace coinbase::crypto;
 
 static void BM_SHA256(benchmark::State& state) {
   buf_t input = gen_random(state.range(0));
-  for (auto _ : state) auto _dummy = sha256_t::hash(input);
+  for (auto _ : state) {
+    auto hash = sha256_t::hash(input);
+    benchmark::DoNotOptimize(hash);
+  }
 }
-BENCHMARK(BM_SHA256)->Name("Core/Hash/SHA256")->RangeMultiplier(4)->Range(1, 4096);
+BENCHMARK(BM_SHA256)->Name("Core/Hash/SHA256")->RangeMultiplier(4)->Range(1 << 4, 1 << 12);
 
 static void BM_HMAC_SHA256(benchmark::State& state) {
   buf_t input = gen_random(state.range(0));
@@ -20,29 +20,36 @@ static void BM_HMAC_SHA256(benchmark::State& state) {
 
   for (auto _ : state) {
     hmac_sha256_t hmac(key);
-    hmac.calculate(input);
+    auto mac = hmac.calculate(input);
+    benchmark::DoNotOptimize(mac);
   }
 }
-BENCHMARK(BM_SHA256)->Name("Core/Hash/HMAC-SHA256")->RangeMultiplier(4)->Range(1, 4096);
+BENCHMARK(BM_HMAC_SHA256)->Name("Core/Hash/HMAC-SHA256")->RangeMultiplier(4)->Range(1 << 4, 1 << 12);
 
-static void BM_AEC_GCM_128(benchmark::State& state) {
+static void BM_AES_GCM_128(benchmark::State& state) {
   buf_t input = gen_random(state.range(0));
 
   buf_t key = gen_random(16);
   buf_t iv = gen_random(12);
 
   buf_t output;
-  for (auto _ : state) aes_gcm_t::encrypt(key, iv, mem_t(), 12, input, output);
+  for (auto _ : state) {
+    aes_gcm_t::encrypt(key, iv, mem_t(), 12, input, output);
+    benchmark::DoNotOptimize(output);
+  }
 }
-BENCHMARK(BM_AEC_GCM_128)->Name("Core/Hash/AES-GCM-128")->RangeMultiplier(4)->Range(1, 4096);
+BENCHMARK(BM_AES_GCM_128)->Name("Core/Hash/AES-GCM-128")->RangeMultiplier(4)->Range(1 << 10, 1 << 22);
 
-static void BM_AEC_GCM_256(benchmark::State& state) {
+static void BM_AES_GCM_256(benchmark::State& state) {
   buf_t input = gen_random(state.range(0));
 
   buf_t key = gen_random(32);
   buf_t iv = gen_random(12);
 
   buf_t output;
-  for (auto _ : state) aes_gcm_t::encrypt(key, iv, mem_t(), 12, input, output);
+  for (auto _ : state) {
+    aes_gcm_t::encrypt(key, iv, mem_t(), 12, input, output);
+    benchmark::DoNotOptimize(output);
+  }
 }
-BENCHMARK(BM_AEC_GCM_128)->Name("Core/Hash/AES-GCM-256")->RangeMultiplier(4)->Range(1, 4096);
+BENCHMARK(BM_AES_GCM_256)->Name("Core/Hash/AES-GCM-256")->RangeMultiplier(4)->Range(1 << 10, 1 << 22);


### PR DESCRIPTION
- Fix BENCHMARK() macros to reference correct functions (BM_HMAC_SHA256, BM_AES_GCM_128, BM_AES_GCM_256) instead of wrong ones
- Fix typo: BM_AEC_GCM -> BM_AES_GCM
- Add benchmark::DoNotOptimize() to prevent compiler from optimizing out hash/encryption results
- Use proper DRBG seeds with sufficient entropy (16 bytes) instead of short "test" string that doesn't meet SEC_P_COM requirement
- Adjust benchmark input ranges for more meaningful measurements