### PR TITLE
bench: Add curve check benchmark and improve benchmark practices

### DIFF
--- a/tools/benchmark/bm_elliptic_curve.cpp
+++ b/tools/benchmark/bm_elliptic_curve.cpp
@@ -5,63 +5,61 @@
 
 using namespace coinbase::crypto;
 
-static void BM_ECAdd(benchmark::State& state, const ecurve_t curve) {
+static void BM_ECAdd(benchmark::State& state, const ecurve_t& curve) {
   ecc_point_t P1 = ro::hash_curve(gen_random(8)).curve(curve);
   ecc_point_t P2 = ro::hash_curve(gen_random(8)).curve(curve);
 
-  ecc_point_t R;
   for (auto _ : state) {
-    auto _dummy = ecc_point_t::add(P1, P2);
+    benchmark::DoNotOptimize(ecc_point_t::add(P1, P2));
   }
 }
 
-static void BM_ECAdd_CT(benchmark::State& state, const ecurve_t curve) {
+static void BM_ECAdd_CT(benchmark::State& state, const ecurve_t& curve) {
   ecc_point_t P1 = ro::hash_curve(gen_random(8)).curve(curve);
   ecc_point_t P2 = ro::hash_curve(gen_random(8)).curve(curve);
 
-  ecc_point_t R;
   for (auto _ : state) {
-    auto _dummy = ecc_point_t::add_consttime(P1, P2);
+    benchmark::DoNotOptimize(ecc_point_t::add_consttime(P1, P2));
   }
 }
 
-static void BM_ECMul(benchmark::State& state, const ecurve_t curve) {
+static void BM_ECMul(benchmark::State& state, const ecurve_t& curve) {
   bn_t x = bn_t::rand(curve.order());
   ecc_point_t P = ro::hash_curve(gen_random(8)).curve(curve);
 
   for (auto _ : state) {
-    auto _dummy = ecc_point_t::mul(P, x);
+    benchmark::DoNotOptimize(ecc_point_t::mul(P, x));
   }
 }
 
-static void BM_ECMul_VT(benchmark::State& state, const ecurve_t curve) {
+static void BM_ECMul_VT(benchmark::State& state, const ecurve_t& curve) {
   vartime_scope_t vartime_scope;
   bn_t x = bn_t::rand(curve.order());
   ecc_point_t P = ro::hash_curve(gen_random(8)).curve(curve);
 
   for (auto _ : state) {
-    auto _dummy = ecc_point_t::mul(P, x);
+    benchmark::DoNotOptimize(ecc_point_t::mul(P, x));
   }
 }
 
-static void BM_ECMulG(benchmark::State& state, const ecurve_t curve) {
+static void BM_ECMulG(benchmark::State& state, const ecurve_t& curve) {
   bn_t x = bn_t::rand(curve.order());
 
   for (auto _ : state) {
-    auto _dummy = curve.mul_to_generator(x);
+    benchmark::DoNotOptimize(curve.mul_to_generator(x));
   }
 }
 
-static void BM_ECMulG_VT(benchmark::State& state, const ecurve_t curve) {
+static void BM_ECMulG_VT(benchmark::State& state, const ecurve_t& curve) {
   vartime_scope_t vartime_scope;
   bn_t x = bn_t::rand(curve.order());
 
   for (auto _ : state) {
-    auto _dummy = curve.mul_to_generator(x);
+    benchmark::DoNotOptimize(curve.mul_to_generator(x));
   }
 }
 
-static void BM_ECMulAdd(benchmark::State& state, const ecurve_t curve) {
+static void BM_ECMulAdd(benchmark::State& state, const ecurve_t& curve) {
   bn_t x = bn_t::rand(curve.order());
   bn_t m = bn_t::rand(curve.order());
   bn_t r = bn_t::rand(curve.order());
@@ -69,7 +67,15 @@ static void BM_ECMulAdd(benchmark::State& state, const ecurve_t curve) {
   ecc_point_t P = r * G;
 
   for (auto _ : state) {
-    auto _dummy = curve.mul_add(x, P, m);
+    benchmark::DoNotOptimize(curve.mul_add(x, P, m));
+  }
+}
+
+static void BM_ECCheck(benchmark::State& state, const ecurve_t& curve) {
+  ecc_point_t P = ro::hash_curve(gen_random(8)).curve(curve);
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(curve.check(P));
   }
 }
 
@@ -97,3 +103,5 @@ BM_CURVE(Core/EC/Multiply_G_VT/Ed25519, BM_ECMulG_VT, curve_ed25519);
 
 BM_CURVE(Core/EC/MulAdd/secp256k1, BM_ECMulAdd, curve_secp256k1);
 BM_CURVE(Core/EC/MulAdd/Ed25519, BM_ECMulAdd, curve_ed25519);
+BM_CURVE(Core/EC/Check/secp256k1, BM_ECCheck, curve_secp256k1);
+BM_CURVE(Core/EC/Check/Ed25519, BM_ECCheck, curve_ed25519);


### PR DESCRIPTION
- Add BM_ECCheck benchmark for secp256k1 and Ed25519 curve point validation. 
- Replace _dummy variables with benchmark::DoNotOptimize() to properly prevent compiler optimizations.
- Pass ecurve_t by const reference instead of by value.