### PR TITLE
refactor: extract FFI memory adapters into separate cbmpc/ffi module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,12 @@ add_subdirectory(src/cbmpc/core)
 add_subdirectory(src/cbmpc/crypto)
 add_subdirectory(src/cbmpc/zk)
 add_subdirectory(src/cbmpc/protocol)
+add_subdirectory(src/cbmpc/ffi)
 
 add_library(
   cbmpc STATIC $<TARGET_OBJECTS:cbmpc_core> $<TARGET_OBJECTS:cbmpc_crypto>
-               $<TARGET_OBJECTS:cbmpc_zk> $<TARGET_OBJECTS:cbmpc_protocol>)
+               $<TARGET_OBJECTS:cbmpc_zk> $<TARGET_OBJECTS:cbmpc_protocol>
+               $<TARGET_OBJECTS:cbmpc_ffi>)
 
 link_openssl(cbmpc)
 

--- a/demos-go/cb-mpc-go/internal/cgobinding/ac.cpp
+++ b/demos-go/cb-mpc-go/internal/cgobinding/ac.cpp
@@ -1,6 +1,7 @@
 #include "ac.h"
 
 #include <cbmpc/core/buf.h>
+#include <cbmpc/ffi/cmem_adapter.h>
 #include <cbmpc/crypto/secret_sharing.h>
 
 using namespace coinbase;
@@ -14,7 +15,7 @@ extern "C" {
 
 // ============ PVE (Access Structure) utilities ================
 crypto_ss_node_ref new_node(int node_type, cmem_t node_name, int threshold) {
-  std::string name = mem_t(node_name).to_string();
+  std::string name = coinbase::ffi::view(node_name).to_string();
   node_t* node = new node_t(node_e(node_type), name, threshold);
   return crypto_ss_node_ref{node};
 }

--- a/demos-go/cb-mpc-go/internal/cgobinding/agree_random.cpp
+++ b/demos-go/cb-mpc-go/internal/cgobinding/agree_random.cpp
@@ -5,6 +5,7 @@
 #include <cbmpc/crypto/base.h>
 #include <cbmpc/protocol/agree_random.h>
 #include <cbmpc/protocol/mpc_job_session.h>
+#include <cbmpc/ffi/cmem_adapter.h>
 
 using namespace coinbase;
 using namespace coinbase::mpc;
@@ -35,7 +36,7 @@ int mpc_agree_random(job_2p_ref* job, int bit_len, cmem_t* out) {
 
     if (err) return static_cast<int>(err);
 
-    *out = out_buf.to_cmem();
+    *out = coinbase::ffi::copy_to_cmem(out_buf);
     return SUCCESS_CODE;
 
   } catch (const std::exception& e) {

--- a/demos-go/cb-mpc-go/internal/cgobinding/eddsamp.cpp
+++ b/demos-go/cb-mpc-go/internal/cgobinding/eddsamp.cpp
@@ -7,6 +7,7 @@
 #include <cbmpc/core/buf.h>
 #include <cbmpc/protocol/eddsa.h>
 #include <cbmpc/protocol/mpc_job_session.h>
+#include <cbmpc/ffi/cmem_adapter.h>
 
 #include "curve.h"
 #include "network.h"
@@ -22,10 +23,10 @@ int mpc_eddsampc_sign(job_mp_ref* j, mpc_eckey_mp_ref* k, cmem_t msg_mem, int si
   job_mp_t* job = static_cast<job_mp_t*>(j->opaque);
   eddsampc::key_t* key = static_cast<eddsampc::key_t*>(k->opaque);
 
-  buf_t msg = coinbase::mem_t(msg_mem);
+  buf_t msg = coinbase::ffi::view(msg_mem);
   buf_t sig;
   error_t err = eddsampc::sign(*job, *key, msg, party_idx_t(sig_receiver), sig);
   if (err) return err;
-  *sig_mem = sig.to_cmem();
+  *sig_mem = coinbase::ffi::copy_to_cmem(sig);
   return 0;
 } 

--- a/demos-go/cb-mpc-go/internal/cgobinding/zk.cpp
+++ b/demos-go/cb-mpc-go/internal/cgobinding/zk.cpp
@@ -1,12 +1,13 @@
 #include "zk.h"
 
 #include <cbmpc/zk/zk_ec.h>
+#include <cbmpc/ffi/cmem_adapter.h>
 
 int zk_dl_prove(ecc_point_ref* Q_ref, cmem_t w_mem, cmem_t sid_mem, uint64_t aux, cmem_t* proof_mem) {
   // Deserialize inputs
   ecc_point_t* Q = static_cast<ecc_point_t*>(Q_ref->opaque);
-  buf_t sid = mem_t(sid_mem);
-  bn_t w = bn_t::from_bin(mem_t(w_mem));
+  buf_t sid = coinbase::ffi::view(sid_mem);
+  bn_t w = bn_t::from_bin(coinbase::ffi::view(w_mem));
 
   // Prove
   coinbase::zk::uc_dl_t zk;
@@ -14,7 +15,7 @@ int zk_dl_prove(ecc_point_ref* Q_ref, cmem_t w_mem, cmem_t sid_mem, uint64_t aux
 
   // Serialize proof
   buf_t proof = coinbase::ser(zk);
-  *proof_mem = proof.to_cmem();
+  *proof_mem = coinbase::ffi::copy_to_cmem(proof);
 
   return SUCCESS;
 }
@@ -23,9 +24,9 @@ int zk_dl_verify(ecc_point_ref* Q_ref, cmem_t proof_mem, cmem_t sid_mem, uint64_
   // Deserialize inputs
   ecc_point_t* Q = static_cast<ecc_point_t*>(Q_ref->opaque);
   coinbase::zk::uc_dl_t zk;
-  buf_t sid = mem_t(sid_mem);
+  buf_t sid = coinbase::ffi::view(sid_mem);
 
-  error_t rv = coinbase::deser(mem_t(proof_mem), zk);
+  error_t rv = coinbase::deser(coinbase::ffi::view(proof_mem), zk);
   if (rv != SUCCESS) return rv;
 
   return zk.verify(*Q, sid, aux);

--- a/src/cbmpc/crypto/base_ecc.cpp
+++ b/src/cbmpc/crypto/base_ecc.cpp
@@ -1032,17 +1032,14 @@ error_t ecdh_t::execute(const ecc_point_t& P, buf_t& out) const {
     return SUCCESS;
   } else {
     buf_t pub_oct = P.to_oct();
-    int size = P.get_curve().size();
-    return exec(ctx, cmem_t(pub_oct), cmem_t{out.alloc(size), size});
+    return exec(ctx, mem_t(pub_oct.data(), pub_oct.size()), out);
   }
 }
 
-error_t ecdh_t::execute(void* ctx, cmem_t pub_key, cmem_t out_secret)  // static
-{
+error_t ecdh_t::execute(void* ctx, mem_t pub_key, buf_t& out_secret) {  // static
   error_t rv = UNINITIALIZED_ERROR;
   const ecc_prv_key_t* key = (const ecc_prv_key_t*)ctx;
   ecurve_t curve = key->get_curve();
-  if (out_secret.size != curve.size()) return coinbase::error(E_BADARG, "Bad ECDH size");
 
   ecc_point_t P;
   {
@@ -1050,8 +1047,7 @@ error_t ecdh_t::execute(void* ctx, cmem_t pub_key, cmem_t out_secret)  // static
     if (rv = P.from_oct(curve, pub_key)) return rv;
   }
 
-  buf_t out = key->ecdh(P);
-  memmove(out_secret.data, out.data(), out_secret.size);
+  out_secret = key->ecdh(P);
   return SUCCESS;
 }
 

--- a/src/cbmpc/crypto/base_ecc.h
+++ b/src/cbmpc/crypto/base_ecc.h
@@ -352,13 +352,13 @@ class ecdsa_signature_t {
 
 class ecdh_t {
  public:
-  typedef error_t (*exec_t)(void* ctx, cmem_t pub_key, cmem_t out_secret);
+  typedef error_t (*exec_t)(void* ctx, mem_t pub_key, buf_t& out_secret);
 
   ecdh_t(const ecc_prv_key_t& _key) : key(&_key), exec(nullptr), ctx(nullptr) {}
   ecdh_t(exec_t _exec, void* _ctx) : key(nullptr), exec(_exec), ctx(_ctx) {}
 
   error_t execute(const ecc_point_t& P, buf_t& out) const;
-  static error_t execute(void* ctx, cmem_t pub_key, cmem_t out_secret);
+  static error_t execute(void* ctx, mem_t pub_key, buf_t& out_secret);
 
  private:
   exec_t exec;

--- a/src/cbmpc/crypto/base_hash.h
+++ b/src/cbmpc/crypto/base_hash.h
@@ -51,7 +51,6 @@ class hash_alg_t {
 class ecc_point_t;
 class ecc_generator_point_t;
 
-inline int get_bin_size(cmem_t mem) { return mem.size; }
 inline int get_bin_size(mem_t mem) { return mem.size; }
 inline int get_bin_size(const buf_t& buf) { return buf.size(); }
 inline int get_bin_size(const buf256_t& v) { return 32; }
@@ -82,10 +81,6 @@ int get_bin_size(const V& v) {
 template <class T>
 T& update_state(T& state, const buf_t& v) {
   return state.update(v.data(), v.size());
-}
-template <class T>
-T& update_state(T& state, cmem_t v) {
-  return state.update(v.data, v.size);
 }
 template <class T>
 T& update_state(T& state, mem_t v) {

--- a/src/cbmpc/crypto/base_pki.cpp
+++ b/src/cbmpc/crypto/base_pki.cpp
@@ -1,25 +1,5 @@
 #include "base_pki.h"
 
-#include "pki_ffi.h"
-
-// ---------------------------------------------------------------------------
-// Weak stubs for callback getters so core C++ unit/integration tests can link
-// without any language-specific FFI layer (Go, Python, Rust, …). When an FFI
-// layer *is* linked, its strong definitions override these stubs, so no
-// duplicate-symbol clashes occur.
-// ---------------------------------------------------------------------------
-
-extern "C" {
-
-__attribute__((weak)) ffi_verify_fn get_ffi_verify_fn(void) { return nullptr; }
-__attribute__((weak)) ffi_sign_fn get_ffi_sign_fn(void) { return nullptr; }
-
-__attribute__((weak)) ffi_kem_encap_fn get_ffi_kem_encap_fn(void) { return nullptr; }
-__attribute__((weak)) ffi_kem_decap_fn get_ffi_kem_decap_fn(void) { return nullptr; }
-__attribute__((weak)) ffi_kem_dk_to_ek_fn get_ffi_kem_dk_to_ek_fn(void) { return nullptr; }
-
-}  // extern "C"
-
 namespace coinbase::crypto {
 
 // For unified PKE types

--- a/src/cbmpc/crypto/base_pki.h
+++ b/src/cbmpc/crypto/base_pki.h
@@ -7,7 +7,6 @@
 #include "base.h"
 #include "base_ecc.h"
 #include "base_rsa.h"
-#include "pki_ffi.h"
 
 namespace coinbase::crypto {
 
@@ -190,115 +189,6 @@ struct kem_policy_ecdh_p256_t {
 };
 
 // ---------------------------------------------------------------------------
-// External KEM types (encapsulate/decapsulate via FFI)
-// ---------------------------------------------------------------------------
-
-struct ffi_kem_ek_t : public buf_t {
-  using buf_t::buf_t;
-  using buf_t::operator=;
-};
-
-struct ffi_kem_dk_t {
-  void* handle = nullptr;  // Opaque process-local handle to the private key
-
-  ffi_kem_dk_t() = default;
-  explicit ffi_kem_dk_t(void* h) : handle(h) {}
-
-  // Derive the public key using user-supplied callback.
-  ffi_kem_ek_t pub() const {
-    ffi_kem_dk_to_ek_fn derive_fn = get_ffi_kem_dk_to_ek_fn();
-    cb_assert(derive_fn && "ffi_kem_dk_to_ek_fn not set");
-
-    cmem_t out;
-    int rc = derive_fn(static_cast<const void*>(handle), &out);
-    cb_assert(rc == 0 && "ffi_kem_dk_to_ek_fn failed");
-
-    ffi_kem_ek_t ek;
-    ek = buf_t::from_cmem(out);
-    return ek;
-  }
-};
-
-// Opaque container for the KEM ciphertext produced by the external PKI.
-struct ffi_kem_ct_t : public buf_t {
-  using buf_t::operator=;
-  using buf_t::buf_t;
-};
-
-// Policy adapter that uses the external KEM FFI:
-// - encapsulate: produce (kem_ct, kem_ss)
-// - decapsulate: recover kem_ss from kem_ct
-struct kem_policy_ffi_t {
-  using ek_t = ffi_kem_ek_t;
-  using dk_t = ffi_kem_dk_t;
-
-  static error_t encapsulate(const ek_t& pub_key, buf_t& kem_ct, buf_t& kem_ss, drbg_aes_ctr_t* drbg) {
-    ffi_kem_encap_fn enc_fn = get_ffi_kem_encap_fn();
-    if (!enc_fn) return E_BADARG;
-    constexpr int rho_size = 32;
-    buf_t rho = drbg ? drbg->gen(rho_size) : gen_random(rho_size);
-    cmem_t ct_out;
-    cmem_t ss_out;
-    int rc = enc_fn(cmem_t{pub_key.data(), pub_key.size()}, cmem_t{rho.data(), rho.size()}, &ct_out, &ss_out);
-    if (rc) return E_CRYPTO;
-    kem_ct = buf_t::from_cmem(ct_out);
-    kem_ss = buf_t::from_cmem(ss_out);
-    return SUCCESS;
-  }
-
-  static error_t decapsulate(const dk_t& prv_key, mem_t kem_ct, buf_t& kem_ss) {
-    ffi_kem_decap_fn dec_fn = get_ffi_kem_decap_fn();
-    if (!dec_fn) return E_BADARG;
-    cmem_t ss_out;
-    int rc = dec_fn(static_cast<const void*>(prv_key.handle), kem_ct, &ss_out);
-    if (rc) return E_CRYPTO;
-    kem_ss = buf_t::from_cmem(ss_out);
-    return SUCCESS;
-  }
-};
-
-// ---------------------------------------------------------------------------
-// External Signing types
-// ---------------------------------------------------------------------------
-
-struct ffi_sign_sk_t : public buf_t {
-  using buf_t::buf_t;
-  using buf_t::operator=;
-
-  ffi_sign_sk_t(const buf_t& other) : buf_t(other) {}
-  ffi_sign_sk_t(buf_t&& other) : buf_t(std::move(other)) {}
-
-  buf_t sign(mem_t hash) const {
-    ffi_sign_fn sign_fn = get_ffi_sign_fn();
-    if (!sign_fn) return buf_t();
-    cmem_t out;
-    int rc = sign_fn(cmem_t{this->data(), this->size()}, cmem_t{hash.data, hash.size}, &out);
-    if (rc) {
-      return buf_t();
-    }
-    buf_t sig = buf_t::from_cmem(out);
-    return sig;
-  }
-};
-
-struct ffi_sign_vk_t : public buf_t {
-  using buf_t::buf_t;
-  using buf_t::operator=;
-
-  // Allow construction from a signing key (they share format here)
-  ffi_sign_vk_t(const ffi_sign_sk_t& sk) : buf_t(sk) {}
-
-  error_t verify(mem_t hash, mem_t signature) const {
-    ffi_verify_fn verify_fn = get_ffi_verify_fn();
-    if (!verify_fn) return E_BADARG;
-    int rc = verify_fn(cmem_t{this->data(), this->size()}, cmem_t{hash.data, hash.size},
-                       cmem_t{signature.data, signature.size});
-    if (rc) return E_CRYPTO;
-    return SUCCESS;
-  }
-};
-
-// ---------------------------------------------------------------------------
 // C++ native unified PKE types
 // ---------------------------------------------------------------------------
 
@@ -400,7 +290,6 @@ struct hybrid_pke_t {
 
 using rsa_pke_t = hybrid_pke_t<rsa_pub_key_t, rsa_prv_key_t, kem_aead_ciphertext_t<kem_policy_rsa_oaep_t>>;
 using ecies_t = hybrid_pke_t<ecc_pub_key_t, ecc_prv_key_t, kem_aead_ciphertext_t<kem_policy_ecdh_p256_t>>;
-using ffi_pke_t = hybrid_pke_t<ffi_kem_ek_t, ffi_kem_dk_t, kem_aead_ciphertext_t<kem_policy_ffi_t>>;
 using unified_pke_t = hybrid_pke_t<pub_key_t, prv_key_t, ciphertext_t>;
 
 template <class SK_T, class VK_T>
@@ -409,7 +298,6 @@ struct sign_scheme_t {
   using vk_t = VK_T;
 };
 
-using ffi_sign_scheme_t = sign_scheme_t<ffi_sign_sk_t, ffi_sign_vk_t>;
 using ecc_sign_scheme_t = sign_scheme_t<ecc_prv_key_t, ecc_pub_key_t>;
 
 }  // namespace coinbase::crypto

--- a/src/cbmpc/crypto/base_rsa.cpp
+++ b/src/cbmpc/crypto/base_rsa.cpp
@@ -235,23 +235,17 @@ error_t rsa_oaep_t::execute(hash_e hash_alg, hash_e mgf_alg, mem_t label, mem_t 
     return SUCCESS;
   }
 
-  cmem_t cmem;
-  if (rv = exec(ctx, int(hash_alg), int(mgf_alg), cmem_t(label), cmem_t(in), &cmem)) return rv;
-
-  out = buf_t::from_cmem(cmem);
+  if (rv = exec(ctx, int(hash_alg), int(mgf_alg), label, in, out)) return rv;
   return SUCCESS;
 }
 
-error_t rsa_oaep_t::execute(void *ctx, int hash_alg, int mgf_alg, cmem_t label, cmem_t in, cmem_t *out) {
+error_t rsa_oaep_t::execute(void *ctx, int hash_alg, int mgf_alg, mem_t label, mem_t in, buf_t &out) {
   error_t rv = UNINITIALIZED_ERROR;
   if (!hash_alg_t::get(hash_e(hash_alg)).valid()) return coinbase::error(E_BADARG);
   if (!hash_alg_t::get(hash_e(mgf_alg)).valid()) return coinbase::error(E_BADARG);
 
-  buf_t buf;
   const rsa_prv_key_t *key = (const rsa_prv_key_t *)ctx;
-  if (rv = key->decrypt_oaep(mem_t(in), hash_e(hash_alg), hash_e(mgf_alg), mem_t(label), buf)) return rv;
-
-  *out = buf.to_cmem();
+  if (rv = key->decrypt_oaep(in, hash_e(hash_alg), hash_e(mgf_alg), label, out)) return rv;
   return SUCCESS;
 }
 

--- a/src/cbmpc/crypto/base_rsa.h
+++ b/src/cbmpc/crypto/base_rsa.h
@@ -108,13 +108,13 @@ class rsa_prv_key_t : public scoped_ptr_t<RSA_BASE> {
 
 class rsa_oaep_t {
  public:
-  typedef error_t (*exec_t)(void *ctx, int hash_alg, int mgf_alg, cmem_t label, cmem_t input, cmem_t *output);
+  typedef error_t (*exec_t)(void *ctx, int hash_alg, int mgf_alg, mem_t label, mem_t input, buf_t &output);
 
   rsa_oaep_t(const rsa_prv_key_t &_key) : key(&_key), exec(nullptr), ctx(nullptr) {}
   rsa_oaep_t(exec_t _exec, void *_ctx) : key(nullptr), exec(_exec), ctx(_ctx) {}
 
   error_t execute(hash_e hash_alg, hash_e mgf_alg, mem_t label, mem_t in, buf_t &out) const;
-  static error_t execute(void *ctx, int hash_alg, int mgf_alg, cmem_t label, cmem_t in, cmem_t *out);
+  static error_t execute(void *ctx, int hash_alg, int mgf_alg, mem_t label, mem_t in, buf_t &out);
 
  private:
   exec_t exec;

--- a/src/cbmpc/ffi/CMakeLists.txt
+++ b/src/cbmpc/ffi/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(cbmpc_ffi OBJECT
+  cmem_adapter.cpp
+  pki.cpp
+)
+
+target_include_directories(cbmpc_ffi PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+# Ensure OpenSSL headers/libs are available (matches other components)
+link_openssl(cbmpc_ffi)
+
+

--- a/src/cbmpc/ffi/cmem_adapter.cpp
+++ b/src/cbmpc/ffi/cmem_adapter.cpp
@@ -1,0 +1,83 @@
+#include "cmem_adapter.h"
+
+#include <cstdlib>
+#include <cstring>
+
+extern "C" {
+// NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+void* cgo_malloc(int size) { return std::malloc(static_cast<size_t>(size)); }
+
+// NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+void cgo_free(void* ptr) { std::free(ptr); }
+}  // extern "C"
+
+namespace coinbase::ffi {
+
+buf_t copy_from_cmem_and_free(cmem_t cmem) {
+  buf_t buf(cmem.data, cmem.size);
+  cgo_free(cmem.data);
+  return buf;
+}
+
+cmem_t copy_to_cmem(mem_t mem) {
+  cmem_t out{nullptr, mem.size};
+  if (mem.size > 0) {
+    out.data = static_cast<uint8_t*>(cgo_malloc(mem.size));
+    if (out.data) std::memmove(out.data, mem.data, mem.size);
+  }
+  return out;
+}
+
+cmem_t copy_to_cmem(const buf_t& buf) { return copy_to_cmem(mem_t(buf)); }
+
+std::vector<mem_t> view_cmems(cmems_t cmems) {
+  std::vector<mem_t> out;
+  if (cmems.count == 0) return out;
+  out.reserve(cmems.count);
+  int offset = 0;
+  for (int i = 0; i < cmems.count; i++) {
+    const int sz = cmems.sizes[i];
+    out.emplace_back(cmems.data + offset, sz);
+    offset += sz;
+  }
+  return out;
+}
+
+std::vector<buf_t> bufs_from_cmems(cmems_t cmems) {
+  auto mems = view_cmems(cmems);
+  std::vector<buf_t> bufs;
+  bufs.reserve(mems.size());
+  for (const auto& m : mems) bufs.emplace_back(m);
+  return bufs;
+}
+
+cmems_t copy_to_cmems(const std::vector<mem_t>& mems) {
+  cmems_t out{0, nullptr, nullptr};
+  const auto count = static_cast<int>(mems.size());
+  if (count == 0) return out;
+
+  // Calculate total bytes.
+  int total = 0;
+  for (const auto& m : mems) total += m.size;
+
+  out.count = count;
+  out.data = static_cast<uint8_t*>(cgo_malloc(total));
+  out.sizes = static_cast<int*>(cgo_malloc(sizeof(int) * count));
+  if (!out.data || !out.sizes) {
+    cgo_free(out.data);
+    cgo_free(out.sizes);
+    return cmems_t{0, nullptr, nullptr};
+  }
+
+  int offset = 0;
+  for (int i = 0; i < count; i++) {
+    out.sizes[i] = mems[i].size;
+    if (mems[i].size) {
+      std::memmove(out.data + offset, mems[i].data, mems[i].size);
+      offset += mems[i].size;
+    }
+  }
+  return out;
+}
+
+}  // namespace coinbase::ffi

--- a/src/cbmpc/ffi/cmem_adapter.h
+++ b/src/cbmpc/ffi/cmem_adapter.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <vector>
+
+#include <cbmpc/core/buf.h>
+#include <cbmpc/core/cmem.h>
+
+// C-callable allocators used by FFI layers (e.g., cgo).
+extern "C" {
+void* cgo_malloc(int size);
+void cgo_free(void* ptr);
+}
+
+namespace coinbase::ffi {
+
+// Non-owning view of a cmem_t as mem_t.
+inline mem_t view(cmem_t cmem) { return mem_t(cmem.data, cmem.size); }
+
+// Copy cmem into a new buf_t and free the source buffer.
+buf_t copy_from_cmem_and_free(cmem_t cmem);
+
+// Copy mem/buf into freshly allocated cmem_t owned by the caller.
+cmem_t copy_to_cmem(mem_t mem);
+cmem_t copy_to_cmem(const buf_t& buf);
+
+// Non-owning view of cmems_t (no freeing).
+std::vector<mem_t> view_cmems(cmems_t cmems);
+
+// Copy cmems_t into new buffers (does not free the source).
+std::vector<buf_t> bufs_from_cmems(cmems_t cmems);
+
+// Convert a flat list of mem views into cmems_t (data + sizes).
+cmems_t copy_to_cmems(const std::vector<mem_t>& mems);
+
+}  // namespace coinbase::ffi

--- a/src/cbmpc/ffi/pki.cpp
+++ b/src/cbmpc/ffi/pki.cpp
@@ -1,0 +1,15 @@
+#include "pki.h"
+
+// Weak stubs for callback getters so core C++ unit/integration tests can link
+// without any language-specific FFI layer (Go, Python, Rust, …). When an FFI
+// layer is linked, its strong definitions override these stubs.
+extern "C" {
+
+__attribute__((weak)) ffi_verify_fn get_ffi_verify_fn(void) { return nullptr; }
+__attribute__((weak)) ffi_sign_fn get_ffi_sign_fn(void) { return nullptr; }
+
+__attribute__((weak)) ffi_kem_encap_fn get_ffi_kem_encap_fn(void) { return nullptr; }
+__attribute__((weak)) ffi_kem_decap_fn get_ffi_kem_decap_fn(void) { return nullptr; }
+__attribute__((weak)) ffi_kem_dk_to_ek_fn get_ffi_kem_dk_to_ek_fn(void) { return nullptr; }
+
+}  // extern "C"

--- a/src/cbmpc/ffi/pki.h
+++ b/src/cbmpc/ffi/pki.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <cbmpc/crypto/base_pki.h>
+#include <cbmpc/crypto/pki_ffi.h>
+
+#include "cmem_adapter.h"
+
+namespace coinbase::crypto {
+
+// External KEM types (encapsulate/decapsulate via FFI)
+struct ffi_kem_ek_t : public buf_t {
+  using buf_t::buf_t;
+  using buf_t::operator=;
+};
+
+struct ffi_kem_dk_t {
+  void* handle = nullptr;  // Opaque process-local handle to the private key
+
+  ffi_kem_dk_t() = default;
+  explicit ffi_kem_dk_t(void* h) : handle(h) {}
+
+  // Derive the public key using user-supplied callback.
+  ffi_kem_ek_t pub() const {
+    ffi_kem_dk_to_ek_fn derive_fn = get_ffi_kem_dk_to_ek_fn();
+    cb_assert(derive_fn && "ffi_kem_dk_to_ek_fn not set");
+
+    cmem_t out{};
+    int rc = derive_fn(static_cast<const void*>(handle), &out);
+    cb_assert(rc == 0 && "ffi_kem_dk_to_ek_fn failed");
+
+    ffi_kem_ek_t ek;
+    ek = ffi::copy_from_cmem_and_free(out);
+    return ek;
+  }
+};
+
+// Opaque container for the KEM ciphertext produced by the external PKI.
+struct ffi_kem_ct_t : public buf_t {
+  using buf_t::operator=;
+  using buf_t::buf_t;
+};
+
+// Policy adapter that uses the external KEM FFI:
+// - encapsulate: produce (kem_ct, kem_ss)
+// - decapsulate: recover kem_ss from kem_ct
+struct kem_policy_ffi_t {
+  using ek_t = ffi_kem_ek_t;
+  using dk_t = ffi_kem_dk_t;
+
+  static error_t encapsulate(const ek_t& pub_key, buf_t& kem_ct, buf_t& kem_ss, drbg_aes_ctr_t* drbg) {
+    ffi_kem_encap_fn enc_fn = get_ffi_kem_encap_fn();
+    if (!enc_fn) return E_BADARG;
+    constexpr int rho_size = 32;
+    buf_t rho = drbg ? drbg->gen(rho_size) : gen_random(rho_size);
+    cmem_t ct_out{};
+    cmem_t ss_out{};
+    int rc = enc_fn(cmem_t{pub_key.data(), pub_key.size()}, cmem_t{rho.data(), rho.size()}, &ct_out, &ss_out);
+    if (rc) return E_CRYPTO;
+    kem_ct = ffi::copy_from_cmem_and_free(ct_out);
+    kem_ss = ffi::copy_from_cmem_and_free(ss_out);
+    return SUCCESS;
+  }
+
+  static error_t decapsulate(const dk_t& prv_key, mem_t kem_ct, buf_t& kem_ss) {
+    ffi_kem_decap_fn dec_fn = get_ffi_kem_decap_fn();
+    if (!dec_fn) return E_BADARG;
+    cmem_t ss_out{};
+    cmem_t kem_ct_c = cmem_t{kem_ct.data, kem_ct.size};
+    int rc = dec_fn(static_cast<const void*>(prv_key.handle), kem_ct_c, &ss_out);
+    if (rc) return E_CRYPTO;
+    kem_ss = ffi::copy_from_cmem_and_free(ss_out);
+    return SUCCESS;
+  }
+};
+
+// External Signing types
+struct ffi_sign_sk_t : public buf_t {
+  using buf_t::buf_t;
+  using buf_t::operator=;
+
+  ffi_sign_sk_t(const buf_t& other) : buf_t(other) {}
+  ffi_sign_sk_t(buf_t&& other) : buf_t(std::move(other)) {}
+
+  buf_t sign(mem_t hash) const {
+    ffi_sign_fn sign_fn = get_ffi_sign_fn();
+    if (!sign_fn) return buf_t();
+    cmem_t out{};
+    int rc = sign_fn(cmem_t{this->data(), this->size()}, cmem_t{hash.data, hash.size}, &out);
+    if (rc) return buf_t();
+    return ffi::copy_from_cmem_and_free(out);
+  }
+};
+
+struct ffi_sign_vk_t : public buf_t {
+  using buf_t::buf_t;
+  using buf_t::operator=;
+
+  // Allow construction from a signing key (they share format here)
+  ffi_sign_vk_t(const ffi_sign_sk_t& sk) : buf_t(sk) {}
+
+  error_t verify(mem_t hash, mem_t signature) const {
+    ffi_verify_fn verify_fn = get_ffi_verify_fn();
+    if (!verify_fn) return E_BADARG;
+    int rc = verify_fn(cmem_t{this->data(), this->size()}, cmem_t{hash.data, hash.size},
+                       cmem_t{signature.data, signature.size});
+    if (rc) return E_CRYPTO;
+    return SUCCESS;
+  }
+};
+
+using ffi_pke_t = hybrid_pke_t<ffi_kem_ek_t, ffi_kem_dk_t, kem_aead_ciphertext_t<kem_policy_ffi_t>>;
+using ffi_sign_scheme_t = sign_scheme_t<ffi_sign_sk_t, ffi_sign_vk_t>;
+
+}  // namespace coinbase::crypto

--- a/tests/unit/protocol/test_ec_dkg.cpp
+++ b/tests/unit/protocol/test_ec_dkg.cpp
@@ -91,24 +91,24 @@ TEST(ECDKG, ReconstructPubAdditiveShares) {
   ASSERT_TRUE(strext::from_hex(q,
                                "043ba974482f15ea45d22ad2022c5168e36ff3e320ef49c36b65388090c2e7bf50fb79a1648f194fdd38733"
                                "a6503a13e5f6be7bf7979ebbf0f33a7849f69886311"));
-  ASSERT_EQ(ks.Q.from_bin(curve, mem_t(q.to_cmem())), 0);
+  ASSERT_EQ(ks.Q.from_bin(curve, mem_t(q.data(), q.size())), 0);
 
   ASSERT_TRUE(strext::from_hex(q,
                                "046df7e34ba10dd371efb4b3c508918115d258a9e05c69869e6bd33804cf1450d1e5a64c161b97063a3d662"
                                "29169d79db391a9f8bfaba0661c9f8aab2f2882409d"));
-  ASSERT_EQ(ks.Qis["p0"].from_bin(curve, mem_t(q.to_cmem())), 0);
+  ASSERT_EQ(ks.Qis["p0"].from_bin(curve, mem_t(q.data(), q.size())), 0);
   ASSERT_TRUE(strext::from_hex(q,
                                "049a17a7674840e077daf26c7a0968eac8b1682b35d2d5dac09be5421b70da590ff9bb515f4bd6e30a5d77c"
                                "87dfeaf9fbf7bf81f7386b5650276afb082d685875a"));
-  ASSERT_EQ(ks.Qis["p1"].from_bin(curve, mem_t(q.to_cmem())), 0);
+  ASSERT_EQ(ks.Qis["p1"].from_bin(curve, mem_t(q.data(), q.size())), 0);
   ASSERT_TRUE(strext::from_hex(q,
                                "048ce1b47d641157ae2ce9636b72f3345e162ea904b8830e96c92a6ec3d5842b8f2955d0ff48d08ef46856e"
                                "f593a71b29be6092e4a5929e606c7eaf75a099394bf"));
-  ASSERT_EQ(ks.Qis["p2"].from_bin(curve, mem_t(q.to_cmem())), 0);
+  ASSERT_EQ(ks.Qis["p2"].from_bin(curve, mem_t(q.data(), q.size())), 0);
   ASSERT_TRUE(strext::from_hex(q,
                                "048ce1b47d641157ae2ce9636b72f3345e162ea904b8830e96c92a6ec3d5842b8f2955d0ff48d08ef46856e"
                                "f593a71b29be6092e4a5929e606c7eaf75a099394bf"));
-  ASSERT_EQ(ks.Qis["p3"].from_bin(curve, mem_t(q.to_cmem())), 0);
+  ASSERT_EQ(ks.Qis["p3"].from_bin(curve, mem_t(q.data(), q.size())), 0);
 
   key_share_mp_t additive_share;
   error_t rv = ks.to_additive_share(ac, quorum, additive_share);
@@ -125,7 +125,7 @@ TEST(ECDKG, ReconstructPubAdditiveShares) {
                                "048ce1b47d641157ae2ce9636b72f3345e162ea904b8830e96c92a6ec3d5842b8f2955d0ff48d08ef46856e"
                                "f593a71b29be6092e4a5929e606c7eaf75a099394bf"));
   ecc_point_t expected_p2;
-  ASSERT_EQ(expected_p2.from_bin(curve, mem_t(expected_bin.to_cmem())), 0);
+  ASSERT_EQ(expected_p2.from_bin(curve, mem_t(expected_bin.data(), expected_bin.size())), 0);
   EXPECT_EQ(additive_share.Qis["p2"], expected_p2);
 }
 

--- a/tests/unit/protocol/test_ecdsa_2p.cpp
+++ b/tests/unit/protocol/test_ecdsa_2p.cpp
@@ -99,7 +99,7 @@ TEST_F(ECDSA2PC, KeygenBatchSignRefreshBatchSign) {
 
     std::vector<buf_t> sig_bufs(DATA_COUNT);
     buf_t session_id;
-    rv = sign_batch(job, session_id, key, coinbase::mems_t(data).mems(), sig_bufs);
+    rv = sign_batch(job, session_id, key, buf_t::to_mems(data), sig_bufs);
     ASSERT_EQ(rv, 0);
     EXPECT_EQ(session_id.size(), SEC_P_COM / 8);
 
@@ -113,10 +113,10 @@ TEST_F(ECDSA2PC, KeygenBatchSignRefreshBatchSign) {
     EXPECT_NE(new_key.x_share, key.x_share);
 
     std::vector<buf_t> new_sig_bufs(DATA_COUNT);
-    rv = sign_batch(job, session_id, new_key, coinbase::mems_t(data).mems(), new_sig_bufs);
+    rv = sign_batch(job, session_id, new_key, buf_t::to_mems(data), new_sig_bufs);
     ASSERT_EQ(rv, 0);
 
-    rv = sign_with_global_abort_batch(job, session_id, new_key, coinbase::mems_t(data).mems(), new_sig_bufs);
+    rv = sign_with_global_abort_batch(job, session_id, new_key, buf_t::to_mems(data), new_sig_bufs);
     ASSERT_EQ(rv, 0);
   });
 
@@ -206,7 +206,7 @@ TEST_F(ECDSA2PC, ParallelKSRS8) {
 
     std::vector<buf_t> sig_bufs;
     buf_t session_id;
-    rv = sign_batch(job, session_id, key, coinbase::mems_t(data[th_i]).mems(), sig_bufs);
+    rv = sign_batch(job, session_id, key, buf_t::to_mems(data[th_i]), sig_bufs);
     ASSERT_EQ(rv, 0);
 
     ecdsa2pc::key_t& new_key = new_keys[th_i][party_index];
@@ -219,9 +219,9 @@ TEST_F(ECDSA2PC, ParallelKSRS8) {
     EXPECT_NE(new_key.x_share, key.x_share);
 
     std::vector<buf_t> new_sig_bufs;
-    rv = sign_batch(job, session_id, key, coinbase::mems_t(data[th_i]).mems(), new_sig_bufs);
+    rv = sign_batch(job, session_id, key, buf_t::to_mems(data[th_i]), new_sig_bufs);
     ASSERT_EQ(rv, 0);
-    rv = sign_with_global_abort_batch(job, session_id, key, coinbase::mems_t(data[th_i]).mems(), new_sig_bufs);
+    rv = sign_with_global_abort_batch(job, session_id, key, buf_t::to_mems(data[th_i]), new_sig_bufs);
     ASSERT_EQ(rv, 0);
   });
 


### PR DESCRIPTION
Move C memory allocation/deallocation utilities (cmem_t, cmems_t) from
  core/buf and crypto/base_pki into a dedicated ffi module. This separates
  FFI-specific concerns from core library types and provides cleaner
  abstraction for Go bindings.

  Changes:
  - Create src/cbmpc/ffi with cmem_adapter.cpp/h for C memory management
  - Move ffi_kem_ek_t and ffi_kem_dk_t types to ffi/pki.h
  - Update all CGO bindings to use ffi::view() and ffi::copy_to_cmem()
  - Remove to_cmem/from_cmem methods from buf_t and mem_t
  - Remove mems_t class and related FFI conversions from core