### PR TITLE
fix: harden ZK verifiers and crypto primitives

### DIFF
--- a/src/cbmpc/crypto/base_bn.cpp
+++ b/src/cbmpc/crypto/base_bn.cpp
@@ -503,6 +503,8 @@ std::vector<bn_t> bn_t::vector_from_bin(mem_t mem, int n, int size, const mod_t&
 
 bn_t bn_t::from_bin_bitlen(mem_t mem, int bits) {  // static
   cb_assert(mem.size == coinbase::bits_to_bytes(bits));
+  // Handle the 0-bit / empty-input case without indexing into `mem`.
+  if (mem.size == 0) return from_bin(mem);
   int unused_bits = bytes_to_bits(mem.size) - bits;
   byte_t mask = 0xff >> unused_bits;
   if (mem[0] == (mem[0] & mask)) return from_bin(mem);

--- a/src/cbmpc/crypto/base_mod.cpp
+++ b/src/cbmpc/crypto/base_mod.cpp
@@ -24,7 +24,7 @@ void mod_t::convert(coinbase::converter_t& converter) {
   converter.convert(m);
   if (!converter.is_write()) {
     if (converter.is_error()) return;
-    if (m <= 0) {
+    if (m <= 1) {
       converter.set_error();
       return;
     }

--- a/src/cbmpc/zk/fischlin.h
+++ b/src/cbmpc/zk/fischlin.h
@@ -43,11 +43,11 @@ struct fischlin_params_t {
   int rho, b, t;
 
   int e_max() const {
-    assert(t < 32);
+    cb_assert(t < 32);
     return 1 << t;
   }
   uint32_t b_mask() const {
-    assert(b < 32);
+    cb_assert(b < 32);
     return (1 << b) - 1;
   }
   void convert(coinbase::converter_t& c) { c.convert(rho, b); }  // t is not sent

--- a/src/cbmpc/zk/zk_paillier.cpp
+++ b/src/cbmpc/zk/zk_paillier.cpp
@@ -528,8 +528,15 @@ error_t pdl_t::verify(const bn_t& c_key, const crypto::paillier_t& paillier, con
 
   const mod_t& N = paillier.get_N();
   ecurve_t curve = Q1.get_curve();
+  if (!curve) return coinbase::error(E_CRYPTO, "pdl_t::verify: Q1 curve is null");
   const mod_t& q = curve.order();
   const auto& G = curve.generator();
+
+  if (rv = curve.check(Q1)) return coinbase::error(rv, "pdl_t::verify: Q1 is not a valid curve point");
+  {
+    crypto::allow_ecc_infinity_t allow_infinity;
+    if (rv = curve.check(R)) return coinbase::error(rv, "pdl_t::verify: R is not a valid curve point");
+  }
 
   bn_t e = crypto::ro::hash_number(c_key, N, Q1, c_r, R, sid, aux).mod(q);
 


### PR DESCRIPTION
- Add parameter validation in ZK verifiers (rho, b bounds, overflow checks)
- Add range checks for proof elements (e, z values) before use
- Add curve point validation for commitment elements (R, A, B arrays)
- Fix secp256k1 mul_add to handle edge cases in vartime/verifier paths
- Fix bn_t::from_bin_bitlen to handle 0-bit input without OOB access
- Reject mod_t deserialization when modulus <= 1