### PR TITLE
fix: security hardening for ZK proofs and protocol input validation

### DIFF
--- a/src/cbmpc/crypto/base_bn.cpp
+++ b/src/cbmpc/crypto/base_bn.cpp
@@ -503,6 +503,8 @@ std::vector<bn_t> bn_t::vector_from_bin(mem_t mem, int n, int size, const mod_t&
 
 bn_t bn_t::from_bin_bitlen(mem_t mem, int bits) {  // static
   cb_assert(mem.size == coinbase::bits_to_bytes(bits));
+  // Handle the 0-bit / empty-input case without indexing into `mem`.
+  if (mem.size == 0) return from_bin(mem);
   int unused_bits = bytes_to_bits(mem.size) - bits;
   byte_t mask = 0xff >> unused_bits;
   if (mem[0] == (mem[0] & mask)) return from_bin(mem);

--- a/src/cbmpc/crypto/base_hash.h
+++ b/src/cbmpc/crypto/base_hash.h
@@ -167,7 +167,11 @@ T& update_state(T& state, const V (&v)[N]) {
 }
 template <class T, typename V>
 T& update_state(T& state, const std::vector<V>& v) {
-  for (std::size_t i = 0; i < (int)v.size(); i++) update_state(state, v[i]);
+  update_state(state, uint64_t(v.size()));
+  for (std::size_t i = 0; i < v.size(); i++) {
+    update_state(state, uint64_t(get_bin_size(v[i])));
+    update_state(state, v[i]);
+  }
   return state;
 }
 template <class T, typename V>
@@ -178,7 +182,11 @@ T& update_state(T& state, const V& v) {
 
 template <class T, typename V>
 T& update_state(T& state, const coinbase::array_view_t<V>& v) {
-  for (int i = 0; i < v.count; i++) update_state(state, v.ptr[i]);
+  update_state(state, uint64_t(v.count));
+  for (int i = 0; i < v.count; i++) {
+    update_state(state, uint64_t(get_bin_size(v.ptr[i])));
+    update_state(state, v.ptr[i]);
+  }
   return state;
 }
 

--- a/src/cbmpc/crypto/base_mod.cpp
+++ b/src/cbmpc/crypto/base_mod.cpp
@@ -24,7 +24,7 @@ void mod_t::convert(coinbase::converter_t& converter) {
   converter.convert(m);
   if (!converter.is_write()) {
     if (converter.is_error()) return;
-    if (m <= 0) {
+    if (m <= 1) {
       converter.set_error();
       return;
     }

--- a/src/cbmpc/protocol/ec_dkg.cpp
+++ b/src/cbmpc/protocol/ec_dkg.cpp
@@ -223,6 +223,8 @@ error_t key_share_mp_t::refresh(job_mp_t& job, buf_t& sid, const key_share_mp_t&
     // Curve check of R._j[l] is done inside the zk verify function further below
 
     if (h._j != h) return coinbase::error(E_CRYPTO);
+    if (R._j.size() != size_t(n)) return coinbase::error(E_CRYPTO, "ec_dkg: inconsistent batch size (R)");
+    if (pi_r._j.size() != size_t(n)) return coinbase::error(E_CRYPTO, "ec_dkg: inconsistent batch size (pi_r)");
 
     if (rv = com_R.id(sid, job.get_pid(j)).set(rho._j, c._j).open(R._j, pi_r._j)) return rv;
     for (int l = 0; l < n; l++) {

--- a/src/cbmpc/protocol/schnorr_2p.cpp
+++ b/src/cbmpc/protocol/schnorr_2p.cpp
@@ -50,6 +50,8 @@ error_t sign_batch(job_2p_t& job, key_t& key, const std::vector<mem_t>& msgs, st
     zk_dl2.prove(R2, k2, sid, 2);
   }
   if (rv = job.p2_to_p1(R2, zk_dl2, sid2)) return rv;
+  if (job.is_p1() && R2.size() != size_t(n_sigs))
+    return coinbase::error(E_CRYPTO, "schnorr_2p: inconsistent batch size (R2)");
 
   if (job.is_p1()) {
     // point checks are covered by the zk proof
@@ -60,6 +62,7 @@ error_t sign_batch(job_2p_t& job, key_t& key, const std::vector<mem_t>& msgs, st
   if (rv = job.p1_to_p2(zk_dl1, R1, com.rand)) return rv;
 
   if (job.is_p2()) {
+    if (R1.size() != size_t(n_sigs)) return coinbase::error(E_CRYPTO, "schnorr_2p: inconsistent batch size (R1)");
     // point checks are covered by the zk proof
     if (rv = com.id(sid1, job.get_pid(party_t::p1)).open(R1)) return rv;
     if (rv = zk_dl1.verify(R1, sid, 1)) return rv;
@@ -102,6 +105,7 @@ error_t sign_batch(job_2p_t& job, key_t& key, const std::vector<mem_t>& msgs, st
   if (rv = job.p2_to_p1(s2)) return rv;
 
   if (job.is_p1()) {
+    if (s2.size() != size_t(n_sigs)) return coinbase::error(E_CRYPTO, "schnorr_2p: inconsistent batch size (s2)");
     for (int i = 0; i < n_sigs; i++) {
       bn_t s, s1;
       MODULO(q) {

--- a/src/cbmpc/protocol/schnorr_mp.cpp
+++ b/src/cbmpc/protocol/schnorr_mp.cpp
@@ -104,6 +104,8 @@ error_t sign_batch(job_mp_t& job, key_t& key, const std::vector<mem_t>& msgs, pa
 
     if (sid._j != sid._i) return coinbase::error(E_CRYPTO);
     if (h._j != h._i) return coinbase::error(E_CRYPTO);
+    if (Ri._j.size() != msgs.size())
+      return coinbase::error(E_CRYPTO, "schnorrmp::sign_batch: inconsistent batch size (Ri)");
     // Verification of Ri._j is done in the zk verify function
     if (rv = pi._j.verify(Ri._j, sid._i, j)) return coinbase::error(rv, "schnorr_mp_t::sign_batch: verify pi failed");
 
@@ -151,6 +153,8 @@ error_t sign_batch(job_mp_t& job, key_t& key, const std::vector<mem_t>& msgs, pa
   if (job.is_party_idx(sig_receiver)) {
     std::vector<bn_t> ss(msgs.size(), 0);
     for (int j = 0; j < n; j++) {
+      if (ssi._j.size() != msgs.size())
+        return coinbase::error(E_CRYPTO, "schnorrmp::sign_batch: inconsistent batch size (ssi)");
       for (size_t l = 0; l < msgs.size(); l++) MODULO(q) ss[l] += ssi._j[l];
     }
 

--- a/src/cbmpc/zk/fischlin.h
+++ b/src/cbmpc/zk/fischlin.h
@@ -43,12 +43,30 @@ struct fischlin_params_t {
   int rho, b, t;
 
   int e_max() const {
-    assert(t < 32);
+    cb_assert(t < 32);
     return 1 << t;
   }
   uint32_t b_mask() const {
-    assert(b < 32);
+    cb_assert(b < 32);
     return (1 << b) - 1;
+  }
+  error_t check() const {
+    if (rho <= 0) return coinbase::error(E_CRYPTO, "rho <= 0");
+    if (b <= 0) return coinbase::error(E_CRYPTO, "b <= 0");
+    if (b >= 32) return coinbase::error(E_CRYPTO, "b >= 32");
+    if (int64_t(b) * int64_t(rho) < SEC_P_COM) return coinbase::error(E_CRYPTO, "b * rho < SEC_P_COM");
+    return SUCCESS;
+  }
+
+  error_t check_with_effective_b(int effective_b) const {
+    if (rho <= 0) return coinbase::error(E_CRYPTO, "rho <= 0");
+    if (b <= 0) return coinbase::error(E_CRYPTO, "b <= 0");
+    if (b >= 32) return coinbase::error(E_CRYPTO, "b >= 32");
+
+    if (effective_b <= 0) return coinbase::error(E_CRYPTO, "effective_b <= 0");
+    if (int64_t(rho) * int64_t(effective_b) < SEC_P_COM)
+      return coinbase::error(E_CRYPTO, "rho * effective_b < SEC_P_COM");
+    return SUCCESS;
   }
   void convert(coinbase::converter_t& c) { c.convert(rho, b); }  // t is not sent
 };

--- a/src/cbmpc/zk/zk_ec.cpp
+++ b/src/cbmpc/zk/zk_ec.cpp
@@ -56,8 +56,8 @@ void uc_dl_t::prove(const ecc_point_t& Q, const bn_t& w, mem_t session_id, uint6
 error_t uc_dl_t::verify(const ecc_point_t& Q, mem_t session_id, uint64_t aux) const {
   error_t rv = UNINITIALIZED_ERROR;
   crypto::vartime_scope_t vartime_scope;
+  if (rv = params.check()) return rv;
   int rho = params.rho;
-  if (params.b * rho < SEC_P_COM) return coinbase::error(E_CRYPTO, "uc_dl_t::verify: b * rho < SEC_P_COM");
   if (int(A.size()) != rho) return coinbase::error(E_CRYPTO, "uc_dl_t::verify: A.size() != rho");
   if (int(e.size()) != rho) return coinbase::error(E_CRYPTO, "uc_dl_t::verify: e.size() != rho");
   if (int(z.size()) != rho) return coinbase::error(E_CRYPTO, "uc_dl_t::verify: z.size() != rho");
@@ -214,11 +214,11 @@ error_t uc_batch_dl_finite_difference_impl_t::verify(const std::vector<ecc_point
                                                      uint64_t aux) const {
   error_t rv = UNINITIALIZED_ERROR;
   int n = int(Q.size());
+  if (n <= 0) return coinbase::error(E_CRYPTO, "uc_batch_dl_t::verify: Q.size() <= 0");
   crypto::vartime_scope_t vartime_scope;
+  const int b_minus_log2n = params.b - int_log2(n);
+  if (rv = params.check_with_effective_b(b_minus_log2n)) return rv;
   int rho = params.rho;
-  if (rho * (params.b - int_log2(n)) < SEC_P_COM)
-    return coinbase::error(E_CRYPTO,
-                           "uc_batch_dl_finite_difference_impl_t::verify: rho * (params.b - int_log2(n)) < SEC_P_COM");
   if (int(R.size()) != rho)
     return coinbase::error(E_CRYPTO, "uc_batch_dl_finite_difference_impl_t::verify: R.size() != rho");
   if (int(e.size()) != rho)
@@ -236,6 +236,10 @@ error_t uc_batch_dl_finite_difference_impl_t::verify(const std::vector<ecc_point
 
   const auto& G = curve.generator();
   uint32_t b_mask = params.b_mask();
+  for (int i = 0; i < rho; i++) {
+    if (rv = curve.check(R[i]))
+      return coinbase::error(rv, "uc_batch_dl_finite_difference_impl_t::verify: R[i] is not on the curve");
+  }
   buf_t common_hash = crypto::ro::hash_string(G, Q, R, session_id, aux).bitlen(2 * SEC_P_COM);
 
   std::vector<ecc_point_t> PQ(n + 1);
@@ -243,9 +247,6 @@ error_t uc_batch_dl_finite_difference_impl_t::verify(const std::vector<ecc_point
   for (int i = 0; i < n; i++) PQ[i + 1] = Q[i];
 
   for (int i = 0; i < rho; i++) {
-    if (rv = curve.check(R[i]))
-      return coinbase::error(rv, "uc_batch_dl_finite_difference_impl_t::verify: R[i] is not on the curve");
-
     bn_t ei = e[i];
     if (ei < 0) ei += q;
 
@@ -290,6 +291,9 @@ error_t dh_t::verify(const ecc_point_t& Q, const ecc_point_t& A, const ecc_point
 
   const auto& G = curve.generator();
   const mod_t& q = curve.order();
+
+  if (rv = crypto::check_right_open_range(0, e, q)) return rv;
+  if (rv = crypto::check_right_open_range(0, z, q)) return rv;
 
   ecc_point_t X = z * G - e * A;
   ecc_point_t Y = z * Q - e * B;

--- a/src/cbmpc/zk/zk_elgamal_com.cpp
+++ b/src/cbmpc/zk/zk_elgamal_com.cpp
@@ -63,8 +63,8 @@ void uc_elgamal_com_t::prove(const ecc_point_t& Q, elg_com_t UV, const bn_t& x, 
 error_t uc_elgamal_com_t::verify(const ecc_point_t& Q, const elg_com_t& UV, mem_t session_id, uint64_t aux) const {
   error_t rv = UNINITIALIZED_ERROR;
   crypto::vartime_scope_t vartime_scope;
+  if (rv = params.check()) return rv;
   int rho = params.rho;
-  if (params.b * rho < SEC_P_COM) return coinbase::error(E_CRYPTO);
   if (int(AB.size()) != rho) return coinbase::error(E_CRYPTO);
   if (int(e.size()) != rho) return coinbase::error(E_CRYPTO);
   if (int(z1.size()) != rho) return coinbase::error(E_CRYPTO);
@@ -160,6 +160,11 @@ error_t elgamal_com_mult_t::verify(const ecc_point_t& Q, const elg_com_t& A, con
 
   const mod_t& q = curve.order();
 
+  if (rv = crypto::check_right_open_range(0, e, q)) return rv;
+  if (rv = crypto::check_right_open_range(0, z1, q)) return rv;
+  if (rv = crypto::check_right_open_range(0, z2, q)) return rv;
+  if (rv = crypto::check_right_open_range(0, z3, q)) return rv;
+
   auto R = crypto::ec_elgamal_commitment_t::commit(Q, z1).rand(z2) - e * B;
   auto A_tag = (z1 * A).rerand(Q, z3) - e * C;
   bn_t e_tag = crypto::ro::hash_number(Q, R, A_tag, A, B, C, session_id, aux).mod(q);
@@ -231,8 +236,8 @@ error_t uc_elgamal_com_mult_private_scalar_t::verify(const ecc_point_t& Q, const
                                                      mem_t session_id, uint64_t aux) {
   error_t rv = UNINITIALIZED_ERROR;
   crypto::vartime_scope_t vartime_scope;
+  if (rv = params.check()) return rv;
   int rho = params.rho;
-  if (params.b * rho < SEC_P_COM) return coinbase::error(E_CRYPTO);
   if (int(A1_tag.size()) != rho) return coinbase::error(E_CRYPTO);
   if (int(A2_tag.size()) != rho) return coinbase::error(E_CRYPTO);
   if (int(e.size()) != rho) return coinbase::error(E_CRYPTO);
@@ -249,6 +254,16 @@ error_t uc_elgamal_com_mult_private_scalar_t::verify(const ecc_point_t& Q, const
   const mod_t& q = curve.order();
   const auto& G = curve.generator();
   uint16_t b_mask = params.b_mask();
+
+  for (int i = 0; i < rho; i++) {
+    if (rv = curve.check(A1_tag[i]))
+      return coinbase::error(rv, "uc_elgamal_com_mult_private_scalar_t::verify: check A1_tag failed");
+    if (rv = curve.check(A2_tag[i]))
+      return coinbase::error(rv, "uc_elgamal_com_mult_private_scalar_t::verify: check A2_tag failed");
+    if (rv = crypto::check_right_open_range(0, z1[i], q)) return rv;
+    if (rv = crypto::check_right_open_range(0, z2[i], q)) return rv;
+  }
+
   buf_t common_hash = crypto::ro::hash_string(Q, A, B, A1_tag, A2_tag, session_id, aux).bitlen(2 * SEC_P_COM);
 
   bn_t z1_sum = 0;
@@ -258,11 +273,6 @@ error_t uc_elgamal_com_mult_private_scalar_t::verify(const ecc_point_t& Q, const
   ecc_point_t A2_sum = curve.infinity();
 
   for (int i = 0; i < rho; i++) {
-    if (rv = curve.check(A1_tag[i]))
-      return coinbase::error(rv, "uc_elgamal_com_mult_private_scalar_t::verify: check A1_tag failed");
-    if (rv = curve.check(A2_tag[i]))
-      return coinbase::error(rv, "uc_elgamal_com_mult_private_scalar_t::verify: check A2_tag failed");
-
     bn_t sigma = bn_t::rand_bitlen(SEC_P_STAT);
     MODULO(q) {
       z1_sum += sigma * z1[i];

--- a/src/cbmpc/zk/zk_paillier.cpp
+++ b/src/cbmpc/zk/zk_paillier.cpp
@@ -528,8 +528,15 @@ error_t pdl_t::verify(const bn_t& c_key, const crypto::paillier_t& paillier, con
 
   const mod_t& N = paillier.get_N();
   ecurve_t curve = Q1.get_curve();
+  if (!curve) return coinbase::error(E_CRYPTO, "pdl_t::verify: Q1 curve is null");
   const mod_t& q = curve.order();
   const auto& G = curve.generator();
+
+  if (rv = curve.check(Q1)) return coinbase::error(rv, "pdl_t::verify: Q1 is not a valid curve point");
+  {
+    crypto::allow_ecc_infinity_t allow_infinity;
+    if (rv = curve.check(R)) return coinbase::error(rv, "pdl_t::verify: R is not a valid curve point");
+  }
 
   bn_t e = crypto::ro::hash_number(c_key, N, Q1, c_r, R, sid, aux).mod(q);
 

--- a/tests/unit/crypto/test_base_hash.cpp
+++ b/tests/unit/crypto/test_base_hash.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include <cbmpc/crypto/base.h>
+
+namespace {
+
+using namespace coinbase;
+using namespace coinbase::crypto;
+
+TEST(BaseHash, MemTVectorEncodesBoundariesAndLength) {
+  const std::vector<mem_t> msgs_a = {mem_t("a"), mem_t("bc")};  // concat: "abc"
+  const std::vector<mem_t> msgs_b = {mem_t("ab"), mem_t("c")};  // concat: "abc"
+  const std::vector<mem_t> msgs_c = {mem_t("abc")};             // concat: "abc"
+
+  const auto ha = sha256_t::hash(msgs_a);
+  const auto hb = sha256_t::hash(msgs_b);
+  const auto hc = sha256_t::hash(msgs_c);
+
+  EXPECT_NE(ha, hb);
+  EXPECT_NE(ha, hc);
+  EXPECT_NE(hb, hc);
+}
+
+}  // namespace


### PR DESCRIPTION
- Add input range checks and curve point validation in ZK verifiers
- Add Fischlin parameter validation with check() methods
- Fix hash encoding for vectors to include length/size prefixes
- Add batch size consistency checks in ECDSA, Schnorr, and DKG protocols
- Handle edge cases: secp256k1 infinity points, 0-bit bn_t, mod_t m<=1
- Add unit test for hash vector encoding