### PR TITLE
chore: update release workflow to use semantic version tags

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -39,10 +39,10 @@ jobs:
       id: attestation
       uses: "actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0"
       with:
-        subject-path: ${{ github.ref_name }}/${{ github.ref_name }}.tar.gz
+        subject-path: ${{ github.ref_name }}/cb-mpc-${{ github.ref_name }}.tar.gz
 
     - name: release
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        gh release create ${{ github.ref_name }} -t "CB-MPC $VERSION" -d --notes " " -R ${{ github.repository }} ${{ github.ref_name }}/${{ github.ref_name }}.tar.gz ${{ steps.attestation.outputs.bundle-path }}
+        gh release create ${{ github.ref_name }} -t "CB-MPC $VERSION" -d --notes " " -R ${{ github.repository }} ${{ github.ref_name }}/cb-mpc-${{ github.ref_name }}.tar.gz ${{ steps.attestation.outputs.bundle-path }}

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -12,7 +12,7 @@ cd $ROOT_PATH
 
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <ref_name>"
-  echo "  ref_name: The release tag name (e.g. cb-mpc-1.0.0)"
+  echo "  ref_name: The release tag name (e.g. v1.0.0)"
   exit 1
 fi
 
@@ -22,7 +22,7 @@ make clean
 make clean-demos
 make clean-bench
 
-tar -czf "${REF_NAME}.tar.gz" \
+tar -czf "cb-mpc-${REF_NAME}.tar.gz" \
   --exclude='.git' \
   --exclude='.github' \
   --exclude='.buildkite' \


### PR DESCRIPTION
Change the tag pattern from cb-mpc-* to v[0-9]*.[0-9]*.[0-9]* to match semantic version tags like v0.1.1, v1.0.0, etc.