### PR TITLE
[security] Fix input-validation and key-blob integrity bugs

### DIFF
--- a/include-internal/cbmpc/internal/crypto/base_bn.h
+++ b/include-internal/cbmpc/internal/crypto/base_bn.h
@@ -45,6 +45,7 @@ class paillier_t;
 class ecdsa_signature_t;
 class ecurve_t;
 class ecc_point_t;
+class scoped_modulo_t;
 
 typedef void (*gen_prime_callback)(int a, int b, void* ctx);
 
@@ -211,25 +212,21 @@ class bn_t {
   void init();
 };
 
-/**
- * WARNING: `MODULO(n)` sets a thread-local modulus for all `bn_t` arithmetic in the current thread.
- *
- * The modulus is reset in the `for` loop update clause, so it is NOT reset if the body exits early
- * via `return`, `break`, `throw`, `goto`, etc. If that happens, subsequent cryptographic operations
- * on the same thread may run under an unexpected modulus (or under a modulus when they should not),
- * potentially producing incorrect results or corrupted state.
- *
- * Additional caveats:
- * - The modulus is stored as a single thread-local pointer (it is not stacked), so `MODULO(...)`
- *   must not be nested.
- * - Avoid mixing arithmetic that assumes "no modulus" with code that can leave a previous modulus set.
- *
- * If early-exit behavior is required, ensure the modulus is reset before leaving the scope, or refactor
- * to propagate errors without exiting the `MODULO(...) { ... }` block.
- */
-#define MODULO(n)                                                                      \
-  for (coinbase::crypto::bn_t::set_modulo(n); coinbase::crypto::bn_t::check_modulo(n); \
-       coinbase::crypto::bn_t::reset_modulo(n))
+class scoped_modulo_t {
+ public:
+  explicit scoped_modulo_t(const mod_t& mod);
+  ~scoped_modulo_t();
+
+  explicit operator bool() const { return active_; }
+
+ private:
+  const mod_t* previous_ = nullptr;
+  bool active_ = true;
+};
+
+// `MODULO(n)` installs a thread-local modulus for the current scope and restores the previous modulus on every exit
+// path, including exceptions.
+#define MODULO(n) if (coinbase::crypto::scoped_modulo_t _cb_scoped_modulo(n); _cb_scoped_modulo)
 
 const mod_t* thread_local_storage_mod();
 

--- a/include-internal/cbmpc/internal/protocol/pve_batch.h
+++ b/include-internal/cbmpc/internal/protocol/pve_batch.h
@@ -46,12 +46,17 @@ class ec_pve_batch_t {
   const buf_t& get_Label() const { return L; }
 
   void convert(coinbase::converter_t& converter) {
-    if (int(Q.size()) != n) {
+    if (converter.is_write() && int(Q.size()) != n) {
       converter.set_error();
       return;
     }
 
     converter.convert(Q, L, b);
+
+    if (!converter.is_write() && int(Q.size()) != n) {
+      converter.set_error();
+      return;
+    }
 
     for (int i = 0; i < kappa; i++) {
       converter.convert(rows[i].x_bin);

--- a/src/cbmpc/api/ecdsa_mp.cpp
+++ b/src/cbmpc/api/ecdsa_mp.cpp
@@ -40,6 +40,27 @@ struct key_blob_v1_t {
   }
 };
 
+static error_t validate_aggregate_public_key(
+    const coinbase::crypto::ecurve_t& curve, const coinbase::crypto::ecc_point_t& Q,
+    const coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t>& Qis) {
+  coinbase::crypto::ecc_point_t Q_sum = curve.infinity();
+  for (const auto& kv : Qis) Q_sum += kv.second;
+  if (Q != Q_sum) return coinbase::error(E_FORMAT, "invalid key blob");
+  return SUCCESS;
+}
+
+static error_t parse_Qis(const std::map<std::string, buf_t>& Qis_compressed, const coinbase::crypto::ecurve_t& curve,
+                         coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t>& Qis) {
+  error_t rv = UNINITIALIZED_ERROR;
+  Qis.clear();
+  for (const auto& kv : Qis_compressed) {
+    coinbase::crypto::ecc_point_t Qi;
+    if (rv = Qi.from_bin(curve, kv.second)) return coinbase::error(rv, "invalid key blob");
+    Qis[kv.first] = std::move(Qi);
+  }
+  return SUCCESS;
+}
+
 static error_t parse_key_blob_any_version(mem_t in, key_blob_v1_t& out_blob, coinbase::api::curve_id& out_curve_id,
                                           coinbase::crypto::ecurve_t& out_curve) {
   if (const error_t rv =
@@ -163,15 +184,9 @@ static error_t deserialize_key_blob(const coinbase::api::job_mp_t& job, mem_t in
     const std::string name(name_view);
     const auto it = blob.Qis_compressed.find(name);
     if (it == blob.Qis_compressed.end()) return coinbase::error(E_BADARG, "job.party_names mismatch key blob");
-
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, it->second)) return coinbase::error(rv, "invalid key blob");
-    Qis[name] = std::move(Qi);
   }
-
-  coinbase::crypto::ecc_point_t Q_sum = curve.infinity();
-  for (const auto& kv : Qis) Q_sum += kv.second;
-  if (Q != Q_sum) return coinbase::error(E_FORMAT, "invalid key blob");
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
@@ -224,14 +239,10 @@ static error_t deserialize_ac_key_blob(const coinbase::api::job_mp_t& job, mem_t
     const std::string name(name_view);
     const auto it = blob.Qis_compressed.find(name);
     if (it == blob.Qis_compressed.end()) return coinbase::error(E_BADARG, "job.party_names mismatch key blob");
-
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, it->second)) return coinbase::error(rv, "invalid key blob");
-    Qis[name] = std::move(Qi);
   }
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
-  // Access-structure key blobs are validated using the access structure at use sites.
-  // Here we only enforce the self-share binding.
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
   if (it_self == Qis.end()) return coinbase::error(E_FORMAT, "invalid key blob");
@@ -266,11 +277,8 @@ static error_t deserialize_ac_key_blob(mem_t in, coinbase::mpc::ecdsampc::key_t&
   if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
 
   coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
-  for (const auto& kv : blob.Qis_compressed) {
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, kv.second)) return coinbase::error(rv, "invalid key blob");
-    Qis[kv.first] = std::move(Qi);
-  }
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
@@ -473,6 +481,9 @@ error_t get_public_key_compressed(mem_t key_blob, buf_t& pub_key) {
 
   coinbase::crypto::ecc_point_t Q(curve);
   if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   pub_key = Q.to_compressed_bin();
   return SUCCESS;
@@ -499,6 +510,12 @@ error_t detach_private_scalar(mem_t key_blob, buf_t& out_public_key_blob, buf_t&
   const int order_size = q.get_bin_size();
   if (order_size <= 0) return coinbase::error(E_GENERAL, "invalid curve order size");
 
+  coinbase::crypto::ecc_point_t Q(curve);
+  if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
+
   out_private_scalar_fixed = blob.x_share.to_bin(order_size);
 
   // Redact private scalar share.
@@ -518,6 +535,12 @@ error_t attach_private_scalar(mem_t public_key_blob, mem_t private_scalar_fixed,
   const coinbase::crypto::mod_t& q = curve.order();
   const int order_size = q.get_bin_size();
   if (order_size <= 0) return coinbase::error(E_GENERAL, "invalid curve order size");
+
+  coinbase::crypto::ecc_point_t Q(curve);
+  if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   if (const error_t rvm = coinbase::api::detail::validate_mem_arg(private_scalar_fixed, "private_scalar_fixed"))
     return rvm;

--- a/src/cbmpc/api/eddsa_mp.cpp
+++ b/src/cbmpc/api/eddsa_mp.cpp
@@ -35,6 +35,28 @@ struct key_blob_v1_t {
   }
 };
 
+static error_t validate_aggregate_public_key(
+    const coinbase::crypto::ecurve_t& curve, const coinbase::crypto::ecc_point_t& Q,
+    const coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t>& Qis) {
+  coinbase::crypto::ecc_point_t Q_sum = curve.infinity();
+  for (const auto& kv : Qis) Q_sum += kv.second;
+  if (Q != Q_sum) return coinbase::error(E_FORMAT, "invalid key blob");
+  return SUCCESS;
+}
+
+static error_t parse_Qis(const std::map<std::string, buf_t>& Qis_compressed, const coinbase::crypto::ecurve_t& curve,
+                         coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t>& Qis) {
+  error_t rv = UNINITIALIZED_ERROR;
+  Qis.clear();
+  for (const auto& kv : Qis_compressed) {
+    coinbase::crypto::ecc_point_t Qi;
+    if (rv = Qi.from_bin(curve, kv.second)) return coinbase::error(rv, "invalid key blob");
+    if (!Qi.is_in_subgroup()) return coinbase::error(E_FORMAT, "invalid key blob");
+    Qis[kv.first] = std::move(Qi);
+  }
+  return SUCCESS;
+}
+
 static error_t extract_Q_from_key_blob(mem_t in, coinbase::crypto::ecc_point_t& Q) {
   key_blob_v1_t blob;
   error_t rv = coinbase::convert(blob, in);
@@ -48,7 +70,9 @@ static error_t extract_Q_from_key_blob(mem_t in, coinbase::crypto::ecc_point_t& 
   rv = Q.from_bin(curve, blob.Q_compressed);
   if (rv) return coinbase::error(rv, "invalid key blob");
   if (curve.check(Q)) return coinbase::error(E_FORMAT, "invalid key blob");
-  return SUCCESS;
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  return validate_aggregate_public_key(curve, Q, Qis);
 }
 
 static error_t serialize_key_blob_for_party_names(const std::vector<std::string_view>& party_names,
@@ -141,16 +165,9 @@ static error_t deserialize_key_blob(const coinbase::api::job_mp_t& job, mem_t in
     const std::string name(name_view);
     const auto it = blob.Qis_compressed.find(name);
     if (it == blob.Qis_compressed.end()) return coinbase::error(E_BADARG, "job.party_names mismatch key blob");
-
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, it->second)) return coinbase::error(rv, "invalid key blob");
-    if (!Qi.is_in_subgroup()) return coinbase::error(E_FORMAT, "invalid key blob");
-    Qis[name] = std::move(Qi);
   }
-
-  coinbase::crypto::ecc_point_t Q_sum = curve.infinity();
-  for (const auto& kv : Qis) Q_sum += kv.second;
-  if (Q != Q_sum) return coinbase::error(E_FORMAT, "invalid key blob");
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
@@ -202,12 +219,9 @@ static error_t deserialize_ac_key_blob(const coinbase::api::job_mp_t& job, mem_t
     const std::string name(name_view);
     const auto it = blob.Qis_compressed.find(name);
     if (it == blob.Qis_compressed.end()) return coinbase::error(E_BADARG, "job.party_names mismatch key blob");
-
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, it->second)) return coinbase::error(rv, "invalid key blob");
-    if (!Qi.is_in_subgroup()) return coinbase::error(E_FORMAT, "invalid key blob");
-    Qis[name] = std::move(Qi);
   }
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
@@ -242,12 +256,8 @@ static error_t deserialize_ac_key_blob(mem_t in, coinbase::mpc::schnorrmp::key_t
   if (curve.check(Q)) return coinbase::error(E_FORMAT, "invalid key blob");
 
   coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
-  for (const auto& kv : blob.Qis_compressed) {
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, kv.second)) return coinbase::error(rv, "invalid key blob");
-    if (!Qi.is_in_subgroup()) return coinbase::error(E_FORMAT, "invalid key blob");
-    Qis[kv.first] = std::move(Qi);
-  }
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
@@ -472,6 +482,13 @@ error_t detach_private_scalar(mem_t key_blob, buf_t& out_public_key_blob, buf_t&
   const int order_size = q.get_bin_size();
   if (order_size <= 0) return coinbase::error(E_GENERAL, "invalid curve order size");
 
+  coinbase::crypto::ecc_point_t Q(curve);
+  if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+  if (rv = curve.check(Q)) return coinbase::error(rv, "invalid key blob");
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
+
   out_private_scalar_fixed = blob.x_share.to_bin(order_size);
 
   // Wipe private scalar share.
@@ -498,6 +515,13 @@ error_t attach_private_scalar(mem_t public_key_blob, mem_t private_scalar_fixed,
   const coinbase::crypto::mod_t& q = curve.order();
   const int order_size = q.get_bin_size();
   if (order_size <= 0) return coinbase::error(E_GENERAL, "invalid curve order size");
+
+  coinbase::crypto::ecc_point_t Q(curve);
+  if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+  if (rv = curve.check(Q)) return coinbase::error(rv, "invalid key blob");
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   if (const error_t rvm = coinbase::api::detail::validate_mem_arg(private_scalar_fixed, "private_scalar_fixed"))
     return rvm;

--- a/src/cbmpc/api/pve_batch_single_recipient.cpp
+++ b/src/cbmpc/api/pve_batch_single_recipient.cpp
@@ -32,7 +32,7 @@ using detail::parse_ek_blob;
 using detail::rsa_oaep_hsm_base_pke_t;
 
 static error_t parse_batch_ciphertext(mem_t ciphertext, pve_batch_ciphertext_blob_v1_t& out_blob) {
-  error_t rv = coinbase::convert(out_blob, ciphertext);
+  error_t rv = coinbase::deser(ciphertext, out_blob);
   if (rv) return rv;
   if (out_blob.version != pve_batch_ciphertext_version_v1)
     return coinbase::error(E_FORMAT, "unsupported ciphertext version");
@@ -40,6 +40,12 @@ static error_t parse_batch_ciphertext(mem_t ciphertext, pve_batch_ciphertext_blo
   if (out_blob.batch_count > static_cast<uint32_t>(coinbase::mpc::ec_pve_batch_t::MAX_BATCH_COUNT))
     return coinbase::error(E_RANGE, "batch too large");
   return SUCCESS;
+}
+
+static error_t deserialize_batch_ciphertext(mem_t ciphertext, int n, coinbase::mpc::ec_pve_batch_t& out_ct) {
+  if (n <= 0 || n > coinbase::mpc::ec_pve_batch_t::MAX_BATCH_COUNT)
+    return coinbase::error(E_BADARG, "invalid batch count");
+  return coinbase::deser(ciphertext, out_ct);
 }
 
 }  // namespace
@@ -114,7 +120,7 @@ error_t verify_batch(const base_pke_i& base_pke, curve_id curve, mem_t ek, mem_t
 
   base_pke_bridge_t bridge(base_pke);
   coinbase::mpc::ec_pve_batch_t pve_ct(n);
-  if (rv = coinbase::convert(pve_ct, blob.ct)) return rv;
+  if (rv = deserialize_batch_ciphertext(blob.ct, n, pve_ct)) return rv;
 
   for (const auto& q : pve_ct.get_Qs()) {
     if (q.get_curve() != icurve) return coinbase::error(E_BADARG, "ciphertext curve mismatch");
@@ -160,7 +166,7 @@ error_t decrypt_batch(const base_pke_i& base_pke, curve_id curve, mem_t dk, mem_
 
   base_pke_bridge_t bridge(base_pke);
   coinbase::mpc::ec_pve_batch_t pve_ct(n);
-  if (rv = coinbase::convert(pve_ct, blob.ct)) return rv;
+  if (rv = deserialize_batch_ciphertext(blob.ct, n, pve_ct)) return rv;
 
   for (const auto& q : pve_ct.get_Qs()) {
     if (q.get_curve() != icurve) return coinbase::error(E_BADARG, "ciphertext curve mismatch");
@@ -171,7 +177,7 @@ error_t decrypt_batch(const base_pke_i& base_pke, curve_id curve, mem_t dk, mem_
 
   std::vector<coinbase::crypto::bn_t> xs_bn;
   rv = pve_ct.decrypt(bridge, coinbase::mpc::pve_keyref(dk_mem), coinbase::mpc::pve_keyref(ek_mem), label, icurve,
-                      xs_bn, /*skip_verify=*/true);
+                      xs_bn, /*skip_verify=*/false);
   if (rv) {
     out_xs.clear();
     return rv;
@@ -258,7 +264,7 @@ error_t get_public_keys_compressed_batch(mem_t ciphertext, std::vector<buf_t>& o
 
   const int n = static_cast<int>(blob.batch_count);
   coinbase::mpc::ec_pve_batch_t pve_ct(n);  // base PKE not used for extraction
-  if (rv = coinbase::convert(pve_ct, blob.ct)) return rv;
+  if (rv = deserialize_batch_ciphertext(blob.ct, n, pve_ct)) return rv;
 
   std::vector<buf_t> out_local;
   out_local.reserve(static_cast<size_t>(n));
@@ -279,7 +285,7 @@ error_t get_Label_batch(mem_t ciphertext, buf_t& out_label) {
 
   const int n = static_cast<int>(blob.batch_count);
   coinbase::mpc::ec_pve_batch_t pve_ct(n);  // base PKE not used for extraction
-  if (rv = coinbase::convert(pve_ct, blob.ct)) return rv;
+  if (rv = deserialize_batch_ciphertext(blob.ct, n, pve_ct)) return rv;
 
   out_label = pve_ct.get_Label();
   return SUCCESS;

--- a/src/cbmpc/api/schnorr_mp.cpp
+++ b/src/cbmpc/api/schnorr_mp.cpp
@@ -37,6 +37,27 @@ struct key_blob_v1_t {
   }
 };
 
+static error_t validate_aggregate_public_key(
+    const coinbase::crypto::ecurve_t& curve, const coinbase::crypto::ecc_point_t& Q,
+    const coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t>& Qis) {
+  coinbase::crypto::ecc_point_t Q_sum = curve.infinity();
+  for (const auto& kv : Qis) Q_sum += kv.second;
+  if (Q != Q_sum) return coinbase::error(E_FORMAT, "invalid key blob");
+  return SUCCESS;
+}
+
+static error_t parse_Qis(const std::map<std::string, buf_t>& Qis_compressed, const coinbase::crypto::ecurve_t& curve,
+                         coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t>& Qis) {
+  error_t rv = UNINITIALIZED_ERROR;
+  Qis.clear();
+  for (const auto& kv : Qis_compressed) {
+    coinbase::crypto::ecc_point_t Qi;
+    if (rv = Qi.from_bin(curve, kv.second)) return coinbase::error(rv, "invalid key blob");
+    Qis[kv.first] = std::move(Qi);
+  }
+  return SUCCESS;
+}
+
 static error_t extract_Q_from_key_blob(mem_t in, coinbase::crypto::ecc_point_t& Q) {
   key_blob_v1_t blob;
   error_t rv = coinbase::convert(blob, in);
@@ -46,7 +67,12 @@ static error_t extract_Q_from_key_blob(mem_t in, coinbase::crypto::ecc_point_t& 
   if (static_cast<curve_id>(blob.curve) != curve_id::secp256k1)
     return coinbase::error(E_FORMAT, "invalid key blob curve");
   if (blob.Q_compressed.empty()) return coinbase::error(E_FORMAT, "invalid key blob");
-  return Q.from_bin(coinbase::crypto::curve_secp256k1, blob.Q_compressed);
+  const auto curve = coinbase::crypto::curve_secp256k1;
+  if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  return validate_aggregate_public_key(curve, Q, Qis);
 }
 
 static error_t serialize_key_blob_for_party_names(const std::vector<std::string_view>& party_names,
@@ -139,15 +165,9 @@ static error_t deserialize_key_blob(const coinbase::api::job_mp_t& job, mem_t in
     const std::string name(name_view);
     const auto it = blob.Qis_compressed.find(name);
     if (it == blob.Qis_compressed.end()) return coinbase::error(E_BADARG, "job.party_names mismatch key blob");
-
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, it->second)) return coinbase::error(rv, "invalid key blob");
-    Qis[name] = std::move(Qi);
   }
-
-  coinbase::crypto::ecc_point_t Q_sum = curve.infinity();
-  for (const auto& kv : Qis) Q_sum += kv.second;
-  if (Q != Q_sum) return coinbase::error(E_FORMAT, "invalid key blob");
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
@@ -198,14 +218,10 @@ static error_t deserialize_ac_key_blob(const coinbase::api::job_mp_t& job, mem_t
     const std::string name(name_view);
     const auto it = blob.Qis_compressed.find(name);
     if (it == blob.Qis_compressed.end()) return coinbase::error(E_BADARG, "job.party_names mismatch key blob");
-
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, it->second)) return coinbase::error(rv, "invalid key blob");
-    Qis[name] = std::move(Qi);
   }
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
-  // Access-structure key blobs are validated using the access structure at use sites.
-  // Here we only enforce the self-share binding.
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
   if (it_self == Qis.end()) return coinbase::error(E_FORMAT, "invalid key blob");
@@ -238,11 +254,8 @@ static error_t deserialize_ac_key_blob(mem_t in, coinbase::mpc::schnorrmp::key_t
   if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
 
   coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
-  for (const auto& kv : blob.Qis_compressed) {
-    coinbase::crypto::ecc_point_t Qi;
-    if (rv = Qi.from_bin(curve, kv.second)) return coinbase::error(rv, "invalid key blob");
-    Qis[kv.first] = std::move(Qi);
-  }
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   const auto& G = curve.generator();
   const auto it_self = Qis.find(blob.party_name);
@@ -486,6 +499,12 @@ error_t detach_private_scalar(mem_t key_blob, buf_t& out_public_key_blob, buf_t&
   const int order_size = q.get_bin_size();
   if (order_size <= 0) return coinbase::error(E_GENERAL, "invalid curve order size");
 
+  coinbase::crypto::ecc_point_t Q;
+  if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
+
   out_private_scalar_fixed = blob.x_share.to_bin(order_size);
 
   // Wipe private scalar share.
@@ -512,6 +531,12 @@ error_t attach_private_scalar(mem_t public_key_blob, mem_t private_scalar_fixed,
   const coinbase::crypto::mod_t& q = curve.order();
   const int order_size = q.get_bin_size();
   if (order_size <= 0) return coinbase::error(E_GENERAL, "invalid curve order size");
+
+  coinbase::crypto::ecc_point_t Q;
+  if (rv = Q.from_bin(curve, blob.Q_compressed)) return coinbase::error(rv, "invalid key blob");
+  coinbase::crypto::ss::party_map_t<coinbase::crypto::ecc_point_t> Qis;
+  if (rv = parse_Qis(blob.Qis_compressed, curve, Qis)) return rv;
+  if (rv = validate_aggregate_public_key(curve, Q, Qis)) return rv;
 
   if (const error_t rvm = coinbase::api::detail::validate_mem_arg(private_scalar_fixed, "private_scalar_fixed"))
     return rvm;

--- a/src/cbmpc/c_api/access_structure_adapter.h
+++ b/src/cbmpc/c_api/access_structure_adapter.h
@@ -9,6 +9,8 @@
 #include <cbmpc/core/access_structure.h>
 #include <cbmpc/core/error.h>
 
+#include "../api/access_structure_util.h"
+
 namespace coinbase::capi::detail {
 
 inline cbmpc_error_t to_cpp_quorum_party_names(const char* const* names, int names_count,
@@ -33,6 +35,7 @@ inline cbmpc_error_t to_cpp_access_structure(const cbmpc_access_structure_t* in,
   if (!in) return E_BADARG;
   if (in->nodes_count < 0 || in->child_indices_count < 0) return E_BADARG;
   if (in->nodes_count == 0) return E_BADARG;
+  if (static_cast<size_t>(in->nodes_count) > coinbase::api::detail::MAX_ACCESS_STRUCTURE_NODES) return E_RANGE;
   if (!in->nodes) return E_BADARG;
   if (in->child_indices_count > 0 && !in->child_indices) return E_BADARG;
   if (in->root_index < 0 || in->root_index >= in->nodes_count) return E_BADARG;
@@ -42,12 +45,15 @@ inline cbmpc_error_t to_cpp_access_structure(const cbmpc_access_structure_t* in,
 
   struct builder_t {
     static cbmpc_error_t build(const cbmpc_access_structure_t* in, int32_t idx, bool is_root,
-                               std::vector<uint8_t>& state, coinbase::api::access_structure_t& out) {
+                               size_t depth, size_t& nodes_seen, std::vector<uint8_t>& state,
+                               coinbase::api::access_structure_t& out) {
       if (idx < 0 || idx >= in->nodes_count) return E_BADARG;
+      if (depth > coinbase::api::detail::MAX_ACCESS_STRUCTURE_DEPTH) return E_RANGE;
 
       const auto uidx = static_cast<size_t>(idx);
       if (state[uidx] == 1) return E_BADARG;  // cycle
       if (state[uidx] == 2) return E_BADARG;  // node reuse (DAG)
+      if (++nodes_seen > coinbase::api::detail::MAX_ACCESS_STRUCTURE_NODES) return E_RANGE;
       state[uidx] = 1;
 
       const cbmpc_access_structure_node_t& n = in->nodes[uidx];
@@ -93,7 +99,7 @@ inline cbmpc_error_t to_cpp_access_structure(const cbmpc_access_structure_t* in,
           for (int32_t i = 0; i < n.child_indices_count; i++) {
             const int32_t child_idx = in->child_indices[static_cast<size_t>(off + i)];
             coinbase::api::access_structure_t child;
-            const cbmpc_error_t rv = build(in, child_idx, /*is_root=*/false, state, child);
+            const cbmpc_error_t rv = build(in, child_idx, /*is_root=*/false, depth + 1, nodes_seen, state, child);
             if (rv) return rv;
             node.children.emplace_back(std::move(child));
           }
@@ -109,7 +115,8 @@ inline cbmpc_error_t to_cpp_access_structure(const cbmpc_access_structure_t* in,
     }
   };
 
-  const cbmpc_error_t rv = builder_t::build(in, in->root_index, /*is_root=*/true, state, out);
+  size_t nodes_seen = 0;
+  const cbmpc_error_t rv = builder_t::build(in, in->root_index, /*is_root=*/true, /*depth=*/0, nodes_seen, state, out);
   if (rv) return rv;
 
   // Reject unreachable nodes (must be a single rooted tree).

--- a/src/cbmpc/crypto/base_bn.cpp
+++ b/src/cbmpc/crypto/base_bn.cpp
@@ -8,17 +8,13 @@ static thread_local scoped_ptr_t<BN_CTX> g_tls_bn_ctx = nullptr;
 
 static thread_local const mod_t* g_thread_local_storage_modo = nullptr;
 const mod_t* thread_local_storage_mod() { return g_thread_local_storage_modo; }
-/**
- * @notes:
- * - Static analysis flags this as dangerous because it is a single thread-local pointer that affects all `bn_t`
- *   arithmetic on the current thread.
- * - It is intended to be used via the `MODULO(q) { ... }` macro so operations inside the block are performed
- *   modulo `q`.
- * - The macro resets the modulus in the `for` loop update clause; if the block exits early (e.g., `return`,
- *   `break`, `throw`, `goto`), the modulus may remain set and affect subsequent operations on the same thread.
- * - The modulus is not stacked, so `MODULO(...)` must not be nested.
- */
 static void thread_local_storage_set_mod(const mod_t* ptr) { g_thread_local_storage_modo = ptr; }
+
+scoped_modulo_t::scoped_modulo_t(const mod_t& mod) : previous_(thread_local_storage_mod()) {
+  thread_local_storage_set_mod(&mod);
+}
+
+scoped_modulo_t::~scoped_modulo_t() { thread_local_storage_set_mod(previous_); }
 
 BN_CTX* bn_t::thread_local_storage_bn_ctx() {  // static
   BN_CTX* ctx = g_tls_bn_ctx;

--- a/src/cbmpc/protocol/schnorr_2p.cpp
+++ b/src/cbmpc/protocol/schnorr_2p.cpp
@@ -108,6 +108,7 @@ error_t sign_batch(job_2p_t& job, key_t& key, const std::vector<mem_t>& msgs, st
   if (job.is_p1()) {
     if (s2.size() != size_t(n_sigs)) return coinbase::error(E_CRYPTO, "schnorr_2p: inconsistent batch size (s2)");
     for (int i = 0; i < n_sigs; i++) {
+      if (!q.is_in_range(s2[i])) return coinbase::error(E_CRYPTO, "schnorr_2p: invalid s2");
       bn_t s, s1;
       MODULO(q) {
         s1 = e[i] * key.x_share + k1[i];

--- a/tests/unit/c_api/test_access_structure_adapter.cpp
+++ b/tests/unit/c_api/test_access_structure_adapter.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <cbmpc/c_api/access_structure.h>
+#include <cbmpc/core/error.h>
+
+#include <cbmpc/c_api/access_structure_adapter.h>
+
+namespace {
+
+using coinbase::api::detail::MAX_ACCESS_STRUCTURE_DEPTH;
+using coinbase::api::detail::MAX_ACCESS_STRUCTURE_NODES;
+using coinbase::capi::detail::to_cpp_access_structure;
+
+TEST(CApiAccessStructureAdapter, RejectsTooDeepTree) {
+  constexpr size_t kDepth = MAX_ACCESS_STRUCTURE_DEPTH + 1;
+
+  std::vector<cbmpc_access_structure_node_t> nodes(kDepth + 1);
+  std::vector<int32_t> child_indices(kDepth);
+  const char leaf_name[] = "leaf";
+
+  for (size_t i = 0; i < kDepth; i++) {
+    child_indices[i] = static_cast<int32_t>(i + 1);
+    nodes[i] = cbmpc_access_structure_node_t{
+        CBMPC_ACCESS_STRUCTURE_NODE_AND,
+        /*leaf_name=*/nullptr,
+        /*threshold_k=*/0,
+        /*child_indices_offset=*/static_cast<int32_t>(i),
+        /*child_indices_count=*/1,
+    };
+  }
+  nodes[kDepth] = cbmpc_access_structure_node_t{
+      CBMPC_ACCESS_STRUCTURE_NODE_LEAF,
+      leaf_name,
+      /*threshold_k=*/0,
+      /*child_indices_offset=*/0,
+      /*child_indices_count=*/0,
+  };
+
+  const cbmpc_access_structure_t ac = {
+      nodes.data(),
+      static_cast<int32_t>(nodes.size()),
+      child_indices.data(),
+      static_cast<int32_t>(child_indices.size()),
+      /*root_index=*/0,
+  };
+
+  coinbase::api::access_structure_t out;
+  EXPECT_EQ(to_cpp_access_structure(&ac, out), E_RANGE);
+}
+
+TEST(CApiAccessStructureAdapter, RejectsTooManyNodes) {
+  constexpr size_t kLeafCount = MAX_ACCESS_STRUCTURE_NODES;
+
+  std::vector<cbmpc_access_structure_node_t> nodes(kLeafCount + 1);
+  std::vector<int32_t> child_indices(kLeafCount);
+  const char leaf_name[] = "leaf";
+
+  nodes[0] = cbmpc_access_structure_node_t{
+      CBMPC_ACCESS_STRUCTURE_NODE_AND,
+      /*leaf_name=*/nullptr,
+      /*threshold_k=*/0,
+      /*child_indices_offset=*/0,
+      /*child_indices_count=*/static_cast<int32_t>(kLeafCount),
+  };
+
+  for (size_t i = 0; i < kLeafCount; i++) {
+    child_indices[i] = static_cast<int32_t>(i + 1);
+    nodes[i + 1] = cbmpc_access_structure_node_t{
+        CBMPC_ACCESS_STRUCTURE_NODE_LEAF,
+        leaf_name,
+        /*threshold_k=*/0,
+        /*child_indices_offset=*/0,
+        /*child_indices_count=*/0,
+    };
+  }
+
+  const cbmpc_access_structure_t ac = {
+      nodes.data(),
+      static_cast<int32_t>(nodes.size()),
+      child_indices.data(),
+      static_cast<int32_t>(child_indices.size()),
+      /*root_index=*/0,
+  };
+
+  coinbase::api::access_structure_t out;
+  EXPECT_EQ(to_cpp_access_structure(&ac, out), E_RANGE);
+}
+
+}  // namespace

--- a/tests/unit/c_api/test_mp_ac_key_blob_binding.cpp
+++ b/tests/unit/c_api/test_mp_ac_key_blob_binding.cpp
@@ -1,0 +1,201 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+#include <cbmpc/c_api/access_structure.h>
+#include <cbmpc/c_api/ecdsa_mp.h>
+#include <cbmpc/c_api/eddsa_mp.h>
+#include <cbmpc/c_api/job.h>
+#include <cbmpc/c_api/schnorr_mp.h>
+#include <cbmpc/core/error.h>
+#include <cbmpc/internal/core/convert.h>
+#include <cbmpc/internal/crypto/base.h>
+
+#include "test_transport_harness.h"
+
+namespace {
+
+using coinbase::buf_t;
+using coinbase::converter_t;
+using coinbase::mem_t;
+using coinbase::crypto::bn_t;
+using coinbase::testutils::mpc_net_context_t;
+using coinbase::testutils::capi_harness::make_transport;
+using coinbase::testutils::capi_harness::run_mp;
+using coinbase::testutils::capi_harness::transport_ctx_t;
+
+struct key_blob_v1_t {
+  uint32_t version = 0;
+  uint32_t curve = 0;
+  std::string party_name;
+  buf_t Q_compressed;
+  std::map<std::string, buf_t> Qis_compressed;
+  bn_t x_share;
+
+  void convert(converter_t& c) { c.convert(version, curve, party_name, Q_compressed, Qis_compressed, x_share); }
+};
+
+struct api_ops_t {
+  cbmpc_curve_id_t curve;
+  cbmpc_error_t (*dkg_ac)(const cbmpc_mp_job_t*, cbmpc_curve_id_t, cmem_t, const cbmpc_access_structure_t*,
+                          const char* const*, int, cmem_t*, cmem_t*);
+  cbmpc_error_t (*get_public_key)(cmem_t, cmem_t*);
+  cbmpc_error_t (*get_public_share)(cmem_t, cmem_t*);
+  cbmpc_error_t (*detach_private_scalar)(cmem_t, cmem_t*, cmem_t*);
+  cbmpc_error_t (*attach_private_scalar)(cmem_t, cmem_t, cmem_t, cmem_t*);
+};
+
+static cbmpc_access_structure_t make_simple_and_ac() {
+  static const int32_t child_indices[] = {1, 2};
+  static const cbmpc_access_structure_node_t nodes[] = {
+      {CBMPC_ACCESS_STRUCTURE_NODE_AND, /*leaf_name=*/nullptr, /*k=*/0, /*off=*/0, /*cnt=*/2},
+      {CBMPC_ACCESS_STRUCTURE_NODE_LEAF, /*leaf_name=*/"p0", /*k=*/0, /*off=*/0, /*cnt=*/0},
+      {CBMPC_ACCESS_STRUCTURE_NODE_LEAF, /*leaf_name=*/"p1", /*k=*/0, /*off=*/0, /*cnt=*/0},
+  };
+  return cbmpc_access_structure_t{
+      nodes,
+      static_cast<int32_t>(sizeof(nodes) / sizeof(nodes[0])),
+      child_indices,
+      static_cast<int32_t>(sizeof(child_indices) / sizeof(child_indices[0])),
+      0,
+  };
+}
+
+static void make_peers(int n, std::vector<std::shared_ptr<mpc_net_context_t>>& peers) {
+  peers.clear();
+  peers.reserve(n);
+  for (int i = 0; i < n; i++) peers.push_back(std::make_shared<mpc_net_context_t>(i));
+  for (const auto& p : peers) p->init_with_peers(peers);
+}
+
+static void make_transports(const std::vector<std::shared_ptr<mpc_net_context_t>>& peers,
+                            std::vector<transport_ctx_t>& ctxs, std::vector<cbmpc_transport_t>& transports) {
+  ctxs.resize(peers.size());
+  transports.resize(peers.size());
+  for (size_t i = 0; i < peers.size(); i++) {
+    ctxs[i] = transport_ctx_t{peers[i], /*free_calls=*/nullptr};
+    transports[i] = make_transport(&ctxs[i]);
+  }
+}
+
+static void generate_ac_key_blobs(const api_ops_t& api, std::vector<cmem_t>& out_key_blobs) {
+  constexpr int n = 2;
+  std::vector<std::shared_ptr<mpc_net_context_t>> peers;
+  make_peers(n, peers);
+
+  std::vector<transport_ctx_t> ctxs;
+  std::vector<cbmpc_transport_t> transports;
+  make_transports(peers, ctxs, transports);
+
+  const char* party_names[n] = {"p0", "p1"};
+  const char* quorum[n] = {"p0", "p1"};
+  const cbmpc_access_structure_t ac = make_simple_and_ac();
+
+  out_key_blobs.assign(n, cmem_t{nullptr, 0});
+  std::vector<cmem_t> sids(n, cmem_t{nullptr, 0});
+  std::vector<cbmpc_error_t> rvs;
+
+  run_mp(
+      peers,
+      [&](int i) {
+        const cbmpc_mp_job_t job = {
+            /*self=*/i,
+            /*party_names=*/party_names,
+            /*party_names_count=*/n,
+            /*transport=*/&transports[static_cast<size_t>(i)],
+        };
+        return api.dkg_ac(&job, api.curve, /*sid_in=*/cmem_t{nullptr, 0}, &ac, quorum, n,
+                          &out_key_blobs[static_cast<size_t>(i)], &sids[static_cast<size_t>(i)]);
+      },
+      rvs);
+
+  for (auto rv : rvs) ASSERT_EQ(rv, CBMPC_SUCCESS);
+  for (auto sid : sids) cbmpc_cmem_free(sid);
+}
+
+static buf_t tamper_blob_public_key(cmem_t key_blob, cmem_t replacement_pub_key) {
+  key_blob_v1_t blob;
+  EXPECT_EQ(coinbase::deser(mem_t(key_blob.data, key_blob.size), blob), SUCCESS);
+  blob.Q_compressed = buf_t(replacement_pub_key.data, replacement_pub_key.size);
+  return coinbase::convert(blob);
+}
+
+static void expect_ac_blob_public_key_binding(const api_ops_t& api) {
+  std::vector<cmem_t> key_blobs_a;
+  std::vector<cmem_t> key_blobs_b;
+  generate_ac_key_blobs(api, key_blobs_a);
+  generate_ac_key_blobs(api, key_blobs_b);
+
+  cmem_t replacement_pub{nullptr, 0};
+  ASSERT_EQ(api.get_public_key(key_blobs_b[0], &replacement_pub), CBMPC_SUCCESS);
+
+  const buf_t tampered_key_blob = tamper_blob_public_key(key_blobs_a[0], replacement_pub);
+
+  cmem_t out_pub{nullptr, 0};
+  EXPECT_NE(api.get_public_key(cmem_t{const_cast<uint8_t*>(tampered_key_blob.data()), tampered_key_blob.size()}, &out_pub),
+            CBMPC_SUCCESS);
+  EXPECT_EQ(out_pub.data, nullptr);
+  EXPECT_EQ(out_pub.size, 0);
+
+  cmem_t public_blob{nullptr, 0};
+  cmem_t private_scalar{nullptr, 0};
+  ASSERT_EQ(api.detach_private_scalar(key_blobs_a[0], &public_blob, &private_scalar), CBMPC_SUCCESS);
+
+  cmem_t public_share{nullptr, 0};
+  ASSERT_EQ(api.get_public_share(key_blobs_a[0], &public_share), CBMPC_SUCCESS);
+
+  const buf_t tampered_public_blob = tamper_blob_public_key(public_blob, replacement_pub);
+  cmem_t restored{nullptr, 0};
+  EXPECT_NE(api.attach_private_scalar(cmem_t{const_cast<uint8_t*>(tampered_public_blob.data()), tampered_public_blob.size()},
+                                      private_scalar, public_share, &restored),
+            CBMPC_SUCCESS);
+  EXPECT_EQ(restored.data, nullptr);
+  EXPECT_EQ(restored.size, 0);
+
+  cbmpc_cmem_free(restored);
+  cbmpc_cmem_free(public_share);
+  cbmpc_cmem_free(private_scalar);
+  cbmpc_cmem_free(public_blob);
+  cbmpc_cmem_free(out_pub);
+  cbmpc_cmem_free(replacement_pub);
+  for (auto blob : key_blobs_a) cbmpc_cmem_free(blob);
+  for (auto blob : key_blobs_b) cbmpc_cmem_free(blob);
+}
+
+TEST(CApiMpAcKeyBlobBinding, Schnorr) {
+  const api_ops_t api = {
+      CBMPC_CURVE_SECP256K1,
+      cbmpc_schnorr_mp_dkg_ac,
+      cbmpc_schnorr_mp_get_public_key_compressed,
+      cbmpc_schnorr_mp_get_public_share_compressed,
+      cbmpc_schnorr_mp_detach_private_scalar,
+      cbmpc_schnorr_mp_attach_private_scalar,
+  };
+  expect_ac_blob_public_key_binding(api);
+}
+
+TEST(CApiMpAcKeyBlobBinding, Ecdsa) {
+  const api_ops_t api = {
+      CBMPC_CURVE_SECP256K1,
+      cbmpc_ecdsa_mp_dkg_ac,
+      cbmpc_ecdsa_mp_get_public_key_compressed,
+      cbmpc_ecdsa_mp_get_public_share_compressed,
+      cbmpc_ecdsa_mp_detach_private_scalar,
+      cbmpc_ecdsa_mp_attach_private_scalar,
+  };
+  expect_ac_blob_public_key_binding(api);
+}
+
+TEST(CApiMpAcKeyBlobBinding, EdDsa) {
+  const api_ops_t api = {
+      CBMPC_CURVE_ED25519,
+      cbmpc_eddsa_mp_dkg_ac,
+      cbmpc_eddsa_mp_get_public_key_compressed,
+      cbmpc_eddsa_mp_get_public_share_compressed,
+      cbmpc_eddsa_mp_detach_private_scalar,
+      cbmpc_eddsa_mp_attach_private_scalar,
+  };
+  expect_ac_blob_public_key_binding(api);
+}
+
+}  // namespace

--- a/tests/unit/c_api/test_pve_batch.cpp
+++ b/tests/unit/c_api/test_pve_batch.cpp
@@ -6,6 +6,7 @@
 #include <cbmpc/c_api/pve_batch_single_recipient.h>
 #include <cbmpc/core/error.h>
 #include <cbmpc/core/macros.h>
+#include <cbmpc/internal/core/convert.h>
 #include <cbmpc/internal/core/log.h>
 #include <cbmpc/internal/crypto/base_ecc.h>
 
@@ -13,6 +14,14 @@ namespace {
 
 using coinbase::buf_t;
 using coinbase::mem_t;
+
+struct pve_batch_ciphertext_blob_v1_t {
+  uint32_t version = 1;
+  uint32_t batch_count = 0;
+  buf_t ct;
+
+  void convert(coinbase::converter_t& c) { c.convert(version, batch_count, ct); }
+};
 
 static buf_t expected_Q(cbmpc_curve_id_t curve_id, mem_t x) {
   const coinbase::crypto::ecurve_t curve = (curve_id == CBMPC_CURVE_P256)        ? coinbase::crypto::curve_p256
@@ -259,6 +268,41 @@ TEST(CApiPveBatchNeg, Decrypt) {
             CBMPC_SUCCESS);
   EXPECT_NE(cbmpc_pve_batch_decrypt(nullptr, CBMPC_CURVE_SECP256K1, dk, ek, ct, cmem_t{nullptr, 0}, &xs_out),
             CBMPC_SUCCESS);
+
+  cbmpc_cmem_free(ct);
+  cbmpc_cmem_free(dk);
+  cbmpc_cmem_free(ek);
+}
+
+TEST(CApiPveBatchNeg, DecryptRejectsTamperedOuterBatchCount) {
+  dylog_disable_scope_t no_log;
+
+  cmem_t ek{nullptr, 0};
+  cmem_t dk{nullptr, 0};
+  ASSERT_EQ(cbmpc_pve_generate_base_pke_ecies_p256_keypair(&ek, &dk), CBMPC_SUCCESS);
+
+  const cmem_t label = {reinterpret_cast<uint8_t*>(const_cast<char*>("label")), 5};
+  std::array<uint8_t, 32> x_bytes{};
+  x_bytes[0] = 1;
+  int x_size = 32;
+  const cmems_t xs = {1, x_bytes.data(), &x_size};
+
+  cmem_t ct{nullptr, 0};
+  ASSERT_EQ(cbmpc_pve_batch_encrypt(nullptr, CBMPC_CURVE_SECP256K1, ek, label, xs, &ct), CBMPC_SUCCESS);
+
+  pve_batch_ciphertext_blob_v1_t blob;
+  ASSERT_EQ(coinbase::deser(mem_t(ct.data, ct.size), blob), SUCCESS);
+  blob.batch_count = 2;
+  const buf_t tampered = coinbase::convert(blob);
+
+  cmems_t xs_out{0, nullptr, nullptr};
+  EXPECT_NE(cbmpc_pve_batch_decrypt(nullptr, CBMPC_CURVE_SECP256K1, dk, ek,
+                                    cmem_t{const_cast<uint8_t*>(tampered.data()), tampered.size()},
+                                    label, &xs_out),
+            CBMPC_SUCCESS);
+  EXPECT_EQ(xs_out.count, 0);
+  EXPECT_EQ(xs_out.data, nullptr);
+  EXPECT_EQ(xs_out.sizes, nullptr);
 
   cbmpc_cmem_free(ct);
   cbmpc_cmem_free(dk);

--- a/tests/unit/crypto/test_base_bn.cpp
+++ b/tests/unit/crypto/test_base_bn.cpp
@@ -60,6 +60,24 @@ TEST(BigNumber, IntOperatorsHandleIntMin) {
   MODULO(q) { EXPECT_EQ(bn_t(0) + v, expected_mod); }
 }
 
+TEST(BigNumber, ModuloScopeRestoresOnThrow) {
+  const mod_t& q = crypto::curve_ed25519.order();
+  EXPECT_EQ(thread_local_storage_mod(), nullptr);
+
+  struct sentinel_t {};
+
+  try {
+    MODULO(q) {
+      EXPECT_EQ(thread_local_storage_mod(), &q);
+      throw sentinel_t();
+    }
+    FAIL() << "expected throw";
+  } catch (const sentinel_t&) {
+  }
+
+  EXPECT_EQ(thread_local_storage_mod(), nullptr);
+}
+
 TEST(BigNumber, Multiplication) {
   EXPECT_EQ(bn_t(123) * bn_t(456), 56088);
   EXPECT_EQ(bn_t(-123) * bn_t(456), -56088);

--- a/tests/unit/protocol/test_schnorr_2p.cpp
+++ b/tests/unit/protocol/test_schnorr_2p.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <cbmpc/internal/crypto/base_bn.h>
 #include <cbmpc/internal/protocol/eddsa.h>
 #include <cbmpc/internal/protocol/schnorr_2p.h>
 
+#include "unit/api/test_transport_harness.h"
 #include "utils/local_network/mpc_tester.h"
 
 namespace {
@@ -24,6 +26,80 @@ class MPC_EC_2PC : public Network2PC {
 
 using EdDSA2PC = MPC_EC_2PC;
 using BIP340_2PC = MPC_EC_2PC;
+
+namespace {
+
+using coinbase::testutils::mpc_net_context_t;
+using coinbase::testutils::api_harness::local_api_transport_t;
+using coinbase::testutils::api_harness::run_2pc;
+
+class tampering_transport_t final : public coinbase::api::data_transport_i {
+ public:
+  tampering_transport_t(std::shared_ptr<mpc_net_context_t> ctx, bool tamper_second_send, buf_t replacement)
+      : ctx_(std::move(ctx)), tamper_second_send_(tamper_second_send), replacement_(std::move(replacement)) {}
+
+  error_t send(api::party_idx_t receiver, mem_t msg) override {
+    ++send_count_;
+    const mem_t to_send =
+        (tamper_second_send_ && send_count_ == 2) ? mem_t(replacement_.data(), replacement_.size()) : msg;
+    ctx_->send(static_cast<coinbase::mpc::party_idx_t>(receiver), to_send);
+    return SUCCESS;
+  }
+
+  error_t receive(api::party_idx_t sender, buf_t& msg) override {
+    return ctx_->receive(static_cast<coinbase::mpc::party_idx_t>(sender), msg);
+  }
+
+  error_t receive_all(const std::vector<api::party_idx_t>& senders, std::vector<buf_t>& msgs) override {
+    std::vector<coinbase::mpc::party_idx_t> sender_roles;
+    sender_roles.reserve(senders.size());
+    for (const auto sender : senders) sender_roles.push_back(static_cast<coinbase::mpc::party_idx_t>(sender));
+    return ctx_->receive_all(sender_roles, msgs);
+  }
+
+ private:
+  std::shared_ptr<mpc_net_context_t> ctx_;
+  bool tamper_second_send_ = false;
+  int send_count_ = 0;
+  buf_t replacement_;
+};
+
+std::vector<std::shared_ptr<mpc_net_context_t>> make_peers() {
+  std::vector<std::shared_ptr<mpc_net_context_t>> peers;
+  peers.reserve(2);
+  for (int i = 0; i < 2; ++i) peers.push_back(std::make_shared<mpc_net_context_t>(i));
+  for (const auto& peer : peers) peer->init_with_peers(peers);
+  return peers;
+}
+
+std::array<schnorr2p::key_t, 2> make_keys() {
+  std::array<schnorr2p::key_t, 2> keys;
+  auto peers = make_peers();
+  auto t1 = std::make_shared<local_api_transport_t>(peers[0]);
+  auto t2 = std::make_shared<local_api_transport_t>(peers[1]);
+
+  error_t rv1 = UNINITIALIZED_ERROR;
+  error_t rv2 = UNINITIALIZED_ERROR;
+  run_2pc(
+      peers[0], peers[1],
+      [&] {
+        job_2p_t job(party_t::p1, "p0", "p1", *t1);
+        buf_t sid;
+        return eckey::key_share_2p_t::dkg(job, crypto::curve_secp256k1, keys[0], sid);
+      },
+      [&] {
+        job_2p_t job(party_t::p2, "p0", "p1", *t2);
+        buf_t sid;
+        return eckey::key_share_2p_t::dkg(job, crypto::curve_secp256k1, keys[1], sid);
+      },
+      rv1, rv2);
+
+  EXPECT_EQ(rv1, SUCCESS);
+  EXPECT_EQ(rv2, SUCCESS);
+  return keys;
+}
+
+}  // namespace
 
 TEST_F(EdDSA2PC, KeygenSignRefreshSign) {
   const int DATA_COUNT = 7;
@@ -103,6 +179,57 @@ TEST_F(BIP340_2PC, KeygenSignRefreshSign) {
 
   check_key_pair(keys[0], keys[1]);
   check_key_pair(new_keys[0], new_keys[1]);
+}
+
+TEST_F(BIP340_2PC, RejectsOutOfRangeS2WithoutLeakingModuloState) {
+  auto keys = make_keys();
+
+  std::vector<bn_t> malicious_s2(1);
+  malicious_s2[0] = -bn_t(1);
+  const buf_t malicious_payload = coinbase::ser(malicious_s2);
+
+  auto peers = make_peers();
+  tampering_transport_t p1_transport(peers[0], /*tamper_second_send=*/false, buf_t());
+  tampering_transport_t p2_transport(peers[1], /*tamper_second_send=*/true, malicious_payload);
+
+  buf_t msg(32);
+  for (int i = 0; i < msg.size(); ++i) msg[i] = 0x42;
+  std::vector<mem_t> msgs = {msg};
+
+  error_t p1_rv = UNINITIALIZED_ERROR;
+  error_t p2_rv = UNINITIALIZED_ERROR;
+  bool modulo_leaked = true;
+  bool math_poisoned = true;
+
+  std::thread p1([&] {
+    job_2p_t job(party_t::p1, "p0", "p1", p1_transport);
+    std::vector<buf_t> sigs;
+    p1_rv = schnorr2p::sign_batch(job, keys[0], msgs, sigs, schnorr2p::variant_e::BIP340);
+    modulo_leaked = (crypto::thread_local_storage_mod() != nullptr);
+
+    try {
+      bn_t q_as_bn = keys[0].curve.order();
+      (void)(q_as_bn + bn_t(1));
+      math_poisoned = false;
+    } catch (...) {
+      math_poisoned = true;
+    }
+  });
+
+  std::thread p2([&] {
+    job_2p_t job(party_t::p2, "p0", "p1", p2_transport);
+    std::vector<buf_t> sigs;
+    p2_rv = schnorr2p::sign_batch(job, keys[1], msgs, sigs, schnorr2p::variant_e::BIP340);
+  });
+
+  p1.join();
+  p2.join();
+
+  EXPECT_NE(p1_rv, SUCCESS);
+  EXPECT_FALSE(modulo_leaked);
+  EXPECT_FALSE(math_poisoned);
+  EXPECT_EQ(crypto::thread_local_storage_mod(), nullptr);
+  EXPECT_EQ(p2_rv, SUCCESS);
 }
 
 }  // namespace


### PR DESCRIPTION
## What changed

- Tightened PVE batch ciphertext handling so deserialization is strict, the inner `Q` count must match the outer `batch_count`, and decrypt no longer skips verification.
- Added depth and total-node limits inside the C access-structure adapter so malformed trees fail before stack exhaustion.
- Bound AC key blobs to their aggregate public key across Schnorr, ECDSA, and EdDSA APIs, including public-key extraction and scalar detach/attach helpers.
- Hardened Schnorr 2P against malformed `s2` shares and replaced the `MODULO(...)` scope helper with an exception-safe guard that restores thread-local modulus state.

## Why

- The reported issues all came from untrusted input breaking invariants: malformed ciphertext metadata, unbounded recursive access-structure conversion, tampered aggregate public keys in AC blobs, and out-of-range Schnorr partial signatures that could poison thread-local modular arithmetic state.

## Impact

- Malformed PVE ciphertexts now fail closed instead of deserializing into inconsistent state.
- Deep or oversized access structures are rejected early.
- Tampered AC key blobs can no longer substitute a foreign aggregate public key for extraction or scalar restore flows.
- Invalid Schnorr 2P `s2` values now return a protocol error without leaving the thread in a poisoned modular state.

## Validation

- Standalone gtest runner for C API PVE batch tests, including a tampered `batch_count` regression.
- Standalone gtest runner for access-structure adapter depth and node-count regressions.
- Standalone gtest runner covering AC key-blob tampering regressions for Schnorr, ECDSA, and EdDSA.
- Standalone gtest runners for `BigNumber.ModuloScopeRestoresOnThrow` and `BIP340_2PC.RejectsOutOfRangeS2WithoutLeakingModuloState`.
