### PR TITLE
fix: make MODULO macro safe for early returns and nesting via RAII scope guard

### DIFF
--- a/include-internal/cbmpc/internal/crypto/base_bn.h
+++ b/include-internal/cbmpc/internal/crypto/base_bn.h
@@ -211,25 +211,37 @@ class bn_t {
   void init();
 };
 
+namespace detail {
+
+class modulo_scope_t {
+ public:
+  explicit modulo_scope_t(const mod_t& mod);
+  ~modulo_scope_t();
+  explicit operator bool() const { return active_; }
+  void done() { active_ = false; }
+
+  modulo_scope_t(const modulo_scope_t&) = delete;
+  modulo_scope_t& operator=(const modulo_scope_t&) = delete;
+  modulo_scope_t(modulo_scope_t&&) = delete;
+  modulo_scope_t& operator=(modulo_scope_t&&) = delete;
+
+ private:
+  bool active_ = true;
+  const mod_t* previous_mod_ = nullptr;
+};
+
+}  // namespace detail
+
 /**
- * WARNING: `MODULO(n)` sets a thread-local modulus for all `bn_t` arithmetic in the current thread.
+ * `MODULO(n)` temporarily sets a thread-local modulus for all `bn_t` arithmetic in the current thread.
  *
- * The modulus is reset in the `for` loop update clause, so it is NOT reset if the body exits early
- * via `return`, `break`, `throw`, `goto`, etc. If that happens, subsequent cryptographic operations
- * on the same thread may run under an unexpected modulus (or under a modulus when they should not),
- * potentially producing incorrect results or corrupted state.
+ * The previous modulus is restored whenever the statement scope exits, including early `return`, `break`,
+ * `continue`, `throw`, and nested `MODULO(...)` scopes.
  *
- * Additional caveats:
- * - The modulus is stored as a single thread-local pointer (it is not stacked), so `MODULO(...)`
- *   must not be nested.
- * - Avoid mixing arithmetic that assumes "no modulus" with code that can leave a previous modulus set.
- *
- * If early-exit behavior is required, ensure the modulus is reset before leaving the scope, or refactor
- * to propagate errors without exiting the `MODULO(...) { ... }` block.
+ * Prefer this macro over manually calling `bn_t::set_modulo()` / `reset_modulo()`.
  */
-#define MODULO(n)                                                                      \
-  for (coinbase::crypto::bn_t::set_modulo(n); coinbase::crypto::bn_t::check_modulo(n); \
-       coinbase::crypto::bn_t::reset_modulo(n))
+#define MODULO(n) \
+  for (coinbase::crypto::detail::modulo_scope_t cbmpc_modulo_scope(n); cbmpc_modulo_scope; cbmpc_modulo_scope.done())
 
 const mod_t* thread_local_storage_mod();
 

--- a/src/cbmpc/crypto/base_bn.cpp
+++ b/src/cbmpc/crypto/base_bn.cpp
@@ -12,13 +12,21 @@ const mod_t* thread_local_storage_mod() { return g_thread_local_storage_modo; }
  * @notes:
  * - Static analysis flags this as dangerous because it is a single thread-local pointer that affects all `bn_t`
  *   arithmetic on the current thread.
- * - It is intended to be used via the `MODULO(q) { ... }` macro so operations inside the block are performed
- *   modulo `q`.
- * - The macro resets the modulus in the `for` loop update clause; if the block exits early (e.g., `return`,
- *   `break`, `throw`, `goto`), the modulus may remain set and affect subsequent operations on the same thread.
- * - The modulus is not stacked, so `MODULO(...)` must not be nested.
+ * - `MODULO(q) { ... }` wraps this pointer in a scope guard so operations inside the block are performed
+ *   modulo `q`, and the previous modulus is restored on scope exit.
+ * - Manual calls to `bn_t::set_modulo()` / `reset_modulo()` bypass that guard and should be avoided.
  */
 static void thread_local_storage_set_mod(const mod_t* ptr) { g_thread_local_storage_modo = ptr; }
+
+namespace detail {
+
+modulo_scope_t::modulo_scope_t(const mod_t& mod) : previous_mod_(thread_local_storage_mod()) {
+  thread_local_storage_set_mod(&mod);
+}
+
+modulo_scope_t::~modulo_scope_t() { thread_local_storage_set_mod(previous_mod_); }
+
+}  // namespace detail
 
 BN_CTX* bn_t::thread_local_storage_bn_ctx() {  // static
   BN_CTX* ctx = g_tls_bn_ctx;

--- a/src/cbmpc/crypto/ro.cpp
+++ b/src/cbmpc/crypto/ro.cpp
@@ -95,18 +95,32 @@ std::vector<bn_t> hash_numbers_t::mod(const mod_t& p) {
 
 std::vector<bn256_t> hash_numbers_t::mod256(const mod_t& p) {
   cb_assert(l > 0 && "hash_numbers_t::mod(): call count(l) with l > 0 before mod()");
+  const int mod_bits = p.get_bits_count();
+  cb_assert(mod_bits <= 256 && "hash_numbers_t::mod256(): only supports moduli up to 256 bits");
   buf_t h = final();
 
-  int bits_per_value = p.get_bits_count() + SEC_P_COM;
+  int bits_per_value = mod_bits + SEC_P_COM;
   int bytes_per_value = bits_to_bytes(bits_per_value);
   buf_t t = drbg_sample_string(h, bytes_per_value * 8 * l);
 
   std::vector<bn256_t> r(l);
   uint64_t temp[8] = {0};
+  size_t copy_size = 0;
+  if (bytes_per_value < 0) {
+    cb_assert(false && "hash_numbers_t::mod256(): negative sample size");
+  } else {
+    copy_size = static_cast<size_t>(bytes_per_value);
+  }
+  if (copy_size > sizeof(temp)) {
+    cb_assert(false && "hash_numbers_t::mod256(): sampled value exceeds reducer input size");
+    copy_size = sizeof(temp);
+  }
+
   for (int i = 0; i < l; i++) {
     mem_t bin = t.range(i * bytes_per_value, bytes_per_value);
     bin.reverse();
-    memmove(temp, bin.data, bytes_per_value);
+    memcpy(temp, bin.data, copy_size);
+
     MODULO(p) r[i] = bn256_t::reduce(temp);
   }
   coinbase::secure_bzero(byte_ptr(temp), sizeof(temp));

--- a/tests/unit/crypto/test_base_bn.cpp
+++ b/tests/unit/crypto/test_base_bn.cpp
@@ -10,6 +10,11 @@ using namespace coinbase::crypto;
 
 namespace {
 
+error_t return_inside_modulo_scope(const mod_t& q) {
+  MODULO(q) { return E_CRYPTO; }
+  return SUCCESS;
+}
+
 TEST(BigNumber, Addition) {
   EXPECT_EQ(bn_t(123) + bn_t(456), 579);
   EXPECT_EQ(bn_t(-123) + bn_t(456), 333);
@@ -58,6 +63,28 @@ TEST(BigNumber, IntOperatorsHandleIntMin) {
   bn_t expected_mod;
   MODULO(q) { expected_mod = -abs_v; }
   MODULO(q) { EXPECT_EQ(bn_t(0) + v, expected_mod); }
+}
+
+TEST(BigNumber, ModuloScopeRestoresThreadLocalStateAfterEarlyReturn) {
+  const mod_t& q = crypto::curve_ed25519.order();
+
+  ASSERT_EQ(thread_local_storage_mod(), nullptr);
+  EXPECT_EQ(return_inside_modulo_scope(q), E_CRYPTO);
+  EXPECT_EQ(thread_local_storage_mod(), nullptr);
+  EXPECT_EQ(bn_t(10) + bn_t(3), 13);
+}
+
+TEST(BigNumber, ModuloScopeRestoresPreviousNestedModulus) {
+  const mod_t& outer = crypto::curve_ed25519.order();
+  const mod_t& inner = crypto::curve_secp256k1.order();
+
+  ASSERT_EQ(thread_local_storage_mod(), nullptr);
+  MODULO(outer) {
+    ASSERT_EQ(thread_local_storage_mod(), &outer);
+    MODULO(inner) { EXPECT_EQ(thread_local_storage_mod(), &inner); }
+    EXPECT_EQ(thread_local_storage_mod(), &outer);
+  }
+  EXPECT_EQ(thread_local_storage_mod(), nullptr);
 }
 
 TEST(BigNumber, Multiplication) {

--- a/tests/unit/crypto/test_ro.cpp
+++ b/tests/unit/crypto/test_ro.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cbmpc/internal/crypto/base.h>
+#include <cbmpc/internal/crypto/base_bn256.h>
 #include <cbmpc/internal/crypto/ro.h>
 
 using namespace coinbase::crypto;
@@ -63,6 +65,24 @@ TEST(RandomOracle, EncodeAndUpdateConcatenation) {
   buf_t h2 = s2.final();
 
   cb_assert(h1 == h2);
+}
+
+TEST(RandomOracle, HashNumbersMod256StaysWithinCurveOrder) {
+  const mod_t& q = curve_secp256k1.order();
+
+  auto values = ro::hash_numbers(mem_t("mod256"), 7).count(8).mod256(q);
+  auto repeat = ro::hash_numbers(mem_t("mod256"), 7).count(8).mod256(q);
+
+  ASSERT_EQ(values.size(), 8u);
+  ASSERT_EQ(repeat.size(), values.size());
+  for (std::size_t i = 0; i < values.size(); ++i) EXPECT_TRUE(values[i] == repeat[i]);
+  for (const auto& value : values) EXPECT_TRUE((bn_t(value) < q.value()));
+}
+
+TEST(RandomOracle, HashNumbersMod256RejectsModuliWiderThan256Bits) {
+  EXPECT_THROW(
+      { ro::hash_numbers(mem_t("mod256-wide")).count(1).mod256(LARGEST_PRIME_MOD_2048); },
+      coinbase::assertion_failed_t);
 }
 
 }  // namespace


### PR DESCRIPTION


Replace the raw for-loop MODULO macro with an RAII-based modulo_scope_t that saves and restores the thread-local modulus on scope exit. This fixes a latent bug where early return, break, throw, or goto inside a MODULO block would leave a stale modulus set for subsequent operations on the same thread, and enables safe nesting of MODULO scopes.

Add unit tests for early-return restoration and nested modulus scoping.