### PR TITLE
fix: Keep PVE decrypt searching after row failures

### DIFF
--- a/src/cbmpc/protocol/pve.cpp
+++ b/src/cbmpc/protocol/pve.cpp
@@ -153,7 +153,7 @@ error_t ec_pve_t::decrypt(const pve_base_pke_i& base_pke, pve_keyref_t dk, pve_k
 
   for (int i = 0; i < kappa; i++) {
     buf_t x_buf;
-    if (rv = base_pke.decrypt(dk, inner_label, c[i], x_buf)) return rv;
+    if (rv = base_pke.decrypt(dk, inner_label, c[i], x_buf)) continue;
     if (restore_from_decrypted(i, x_buf, curve, x_out) == SUCCESS) {
       return SUCCESS;
     }

--- a/src/cbmpc/protocol/pve_batch.cpp
+++ b/src/cbmpc/protocol/pve_batch.cpp
@@ -197,7 +197,7 @@ error_t ec_pve_batch_t::decrypt(const pve_base_pke_i& base_pke, pve_keyref_t dk,
 
   for (int i = 0; i < kappa; i++) {
     buf_t x_buf;
-    if (rv = base_pke.decrypt(dk, inner_label, rows[i].c, x_buf)) return rv;
+    if (rv = base_pke.decrypt(dk, inner_label, rows[i].c, x_buf)) continue;
     if (restore_from_decrypted(i, x_buf, curve, xs) == SUCCESS) return SUCCESS;
   }
 

--- a/tests/unit/api/test_pve.cpp
+++ b/tests/unit/api/test_pve.cpp
@@ -41,6 +41,26 @@ class toy_base_pke_t final : public coinbase::api::pve::base_pke_i {
   bool mutate_ = false;
 };
 
+class first_decrypt_fails_base_pke_t final : public coinbase::api::pve::base_pke_i {
+ public:
+  error_t encrypt(mem_t /*ek*/, mem_t /*label*/, mem_t plain, mem_t /*rho*/, buf_t& out_ct) const override {
+    out_ct = buf_t(plain);
+    return SUCCESS;
+  }
+
+  error_t decrypt(mem_t /*dk*/, mem_t /*label*/, mem_t ct, buf_t& out_plain) const override {
+    decrypt_calls_++;
+    if (decrypt_calls_ == 1) return E_FORMAT;
+    out_plain = buf_t(ct);
+    return SUCCESS;
+  }
+
+  int decrypt_calls() const { return decrypt_calls_; }
+
+ private:
+  mutable int decrypt_calls_ = 0;
+};
+
 static buf_t expected_Q(curve_id cid, mem_t x) {
   const coinbase::crypto::ecurve_t curve = (cid == curve_id::p256)        ? coinbase::crypto::curve_p256
                                            : (cid == curve_id::secp256k1) ? coinbase::crypto::curve_secp256k1
@@ -137,6 +157,30 @@ TEST(ApiPve, EncryptVerifyDecrypt_CustomBasePke) {
   buf_t x_out;
   ASSERT_EQ(coinbase::api::pve::decrypt(base_pke, curve, dk, ek, ct, label, x_out), SUCCESS);
   EXPECT_EQ(x_out.size(), 32);
+  EXPECT_EQ(x_out, buf_t(x_mem));
+}
+
+TEST(ApiPve, DecryptContinuesAfterRowDecryptFailure) {
+  const first_decrypt_fails_base_pke_t base_pke;
+
+  const curve_id curve = curve_id::secp256k1;
+  const buf_t ek = buf_t("ek");
+  const buf_t dk = buf_t("dk");
+  const buf_t label = buf_t("label");
+
+  std::array<uint8_t, 32> x_bytes{};
+  for (int i = 0; i < 32; i++) x_bytes[static_cast<size_t>(i)] = static_cast<uint8_t>(0x20 + i);
+  const mem_t x_mem(x_bytes.data(), static_cast<int>(x_bytes.size()));
+
+  buf_t ct;
+  ASSERT_EQ(coinbase::api::pve::encrypt(base_pke, curve, ek, label, x_mem, ct), SUCCESS);
+
+  const buf_t Q_expected = expected_Q(curve, x_mem);
+  ASSERT_EQ(coinbase::api::pve::verify(base_pke, curve, ek, ct, Q_expected, label), SUCCESS);
+
+  buf_t x_out;
+  ASSERT_EQ(coinbase::api::pve::decrypt(base_pke, curve, dk, ek, ct, label, x_out), SUCCESS);
+  EXPECT_GE(base_pke.decrypt_calls(), 2);
   EXPECT_EQ(x_out, buf_t(x_mem));
 }
 

--- a/tests/unit/api/test_pve_batch.cpp
+++ b/tests/unit/api/test_pve_batch.cpp
@@ -40,6 +40,26 @@ class toy_base_pke_t final : public coinbase::api::pve::base_pke_i {
   }
 };
 
+class first_decrypt_fails_base_pke_t final : public coinbase::api::pve::base_pke_i {
+ public:
+  error_t encrypt(mem_t /*ek*/, mem_t /*label*/, mem_t plain, mem_t /*rho*/, buf_t& out_ct) const override {
+    out_ct = buf_t(plain);
+    return SUCCESS;
+  }
+
+  error_t decrypt(mem_t /*dk*/, mem_t /*label*/, mem_t ct, buf_t& out_plain) const override {
+    decrypt_calls_++;
+    if (decrypt_calls_ == 1) return E_FORMAT;
+    out_plain = buf_t(ct);
+    return SUCCESS;
+  }
+
+  int decrypt_calls() const { return decrypt_calls_; }
+
+ private:
+  mutable int decrypt_calls_ = 0;
+};
+
 }  // namespace
 
 TEST(ApiPveBatch, EncVerDec_DefBasePke_RsaBlob) {
@@ -88,6 +108,44 @@ TEST(ApiPveBatch, EncVerDec_DefBasePke_RsaBlob) {
 
   std::vector<buf_t> xs_out;
   ASSERT_EQ(coinbase::api::pve::decrypt_batch(curve, dk_blob, ek_blob, ct, label, xs_out), SUCCESS);
+  ASSERT_EQ(xs_out.size(), static_cast<size_t>(n));
+  for (int i = 0; i < n; i++) EXPECT_EQ(xs_out[static_cast<size_t>(i)], buf_t(xs[static_cast<size_t>(i)]));
+}
+
+TEST(ApiPveBatch, DecryptContinuesAfterRowDecryptFailure) {
+  const first_decrypt_fails_base_pke_t base_pke;
+
+  const curve_id curve = curve_id::secp256k1;
+  const buf_t ek = buf_t("ek");
+  const buf_t dk = buf_t("dk");
+  const buf_t label = buf_t("label");
+
+  constexpr int n = 3;
+  std::array<std::array<uint8_t, 32>, n> xs_bytes{};
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < 32; j++)
+      xs_bytes[static_cast<size_t>(i)][static_cast<size_t>(j)] = static_cast<uint8_t>(0x30 + i + j);
+  }
+  std::vector<mem_t> xs;
+  xs.reserve(n);
+  for (int i = 0; i < n; i++) xs.emplace_back(xs_bytes[static_cast<size_t>(i)].data(), 32);
+
+  buf_t ct;
+  ASSERT_EQ(coinbase::api::pve::encrypt_batch(base_pke, curve, ek, label, xs, ct), SUCCESS);
+
+  std::vector<buf_t> Qs_expected;
+  Qs_expected.reserve(n);
+  for (int i = 0; i < n; i++) Qs_expected.push_back(expected_Q(curve, xs[static_cast<size_t>(i)]));
+
+  std::vector<mem_t> Qs_expected_mem;
+  Qs_expected_mem.reserve(n);
+  for (const auto& q : Qs_expected) Qs_expected_mem.emplace_back(q.data(), q.size());
+
+  ASSERT_EQ(coinbase::api::pve::verify_batch(base_pke, curve, ek, ct, Qs_expected_mem, label), SUCCESS);
+
+  std::vector<buf_t> xs_out;
+  ASSERT_EQ(coinbase::api::pve::decrypt_batch(base_pke, curve, dk, ek, ct, label, xs_out), SUCCESS);
+  EXPECT_GE(base_pke.decrypt_calls(), 2);
   ASSERT_EQ(xs_out.size(), static_cast<size_t>(n));
   for (int i = 0; i < n; i++) EXPECT_EQ(xs_out[static_cast<size_t>(i)], buf_t(xs[static_cast<size_t>(i)]));
 }


### PR DESCRIPTION
PVE ciphertexts include multiple trial rows, so a base PKE decrypt failure on one row should not prevent decrypt from attempting subsequent rows. Continue through decrypt failures for both single and batch PVE, and add tests covering recovery when the first row fails.