### PR TITLE
test: harmless CI trigger probe

### DIFF
--- a/tests/public_headers_smoke.cpp
+++ b/tests/public_headers_smoke.cpp
@@ -1,3 +1,4 @@
+// ci-probe: harmless external PR trigger check
 // Compile-only smoke test: public headers must not depend on internal headers.
 //
 // This TU is built with include paths limited to:


### PR DESCRIPTION
Minimal harmless test PR to verify whether external PRs against `cb-mpc-go` trigger repository workflows before approval. This changes only a comment in a test file and is intended for security validation. I will close it promptly.