### PR TITLE
fix: harden additive share reconstruction

### DIFF
--- a/include-internal/cbmpc/internal/protocol/ec_dkg.h
+++ b/include-internal/cbmpc/internal/protocol/ec_dkg.h
@@ -77,10 +77,10 @@ struct key_share_mp_t {
  private:
   error_t reconstruct_additive_share(const mod_t& q, const crypto::ss::node_t* node,
                                      const std::set<crypto::pname_t>& quorum_names, bn_t& additive_share,
-                                     bool& is_in_quorum) const;
+                                     bool& is_satisfied) const;
   error_t reconstruct_pub_additive_shares(const crypto::ss::node_t* node, const std::set<crypto::pname_t>& quorum_names,
                                           const crypto::pname_t target, ecc_point_t& pub_additive_shares,
-                                          bool& is_in_quorum) const;
+                                          bool& is_satisfied) const;
 
  public:
   /**

--- a/src/cbmpc/protocol/ec_dkg.cpp
+++ b/src/cbmpc/protocol/ec_dkg.cpp
@@ -474,7 +474,7 @@ error_t key_share_mp_t::refresh_ac(job_mp_t& job, const ecurve_t& curve, buf_t& 
 
 error_t key_share_mp_t::reconstruct_additive_share(const mod_t& q, const node_t* node,
                                                    const std::set<crypto::pname_t>& quorum_names, bn_t& additive_share,
-                                                   bool& is_in_quorum) const {
+                                                   bool& is_satisfied) const {
   error_t rv = UNINITIALIZED_ERROR;
   int n = node->get_n();
 
@@ -484,80 +484,83 @@ error_t key_share_mp_t::reconstruct_additive_share(const mod_t& q, const node_t*
       if (node->name == party_name) {
         additive_share = x_share;
       }
-      is_in_quorum = quorum_names.find(node->name) != quorum_names.end();
+      is_satisfied = quorum_names.find(node->name) != quorum_names.end();
     } break;
 
     case node_e::OR:
+      additive_share = 0;
+      is_satisfied = false;
       for (int i = 0; i < n; i++) {
         bn_t additive_share_from_child;
-        bool child_is_in_quorum = false;
+        bool child_is_satisfied = false;
         rv = reconstruct_additive_share(q, node->children[i], quorum_names, additive_share_from_child,
-                                        child_is_in_quorum);
-        is_in_quorum = is_in_quorum || child_is_in_quorum;
+                                        child_is_satisfied);
+        is_satisfied = is_satisfied || child_is_satisfied;
         if (rv == E_INSUFFICIENT) {
           rv = SUCCESS;
           continue;
         }
         if (rv) return rv;
-        if (!is_in_quorum) {
+        if (!child_is_satisfied) {
           continue;
         }
         additive_share = additive_share_from_child;
         break;
       }
-      if (rv == E_INSUFFICIENT) {
-        return coinbase::error(E_INSUFFICIENT);
-      }
       break;
     case node_e::AND:
-      is_in_quorum = true;
+      additive_share = 0;
+      is_satisfied = true;
       for (int i = 0; i < n; i++) {
         bn_t additive_share_from_child;
-        bool child_is_in_quorum = false;
+        bool child_is_satisfied = false;
         rv = reconstruct_additive_share(q, node->children[i], quorum_names, additive_share_from_child,
-                                        child_is_in_quorum);
-        is_in_quorum = is_in_quorum && child_is_in_quorum;
+                                        child_is_satisfied);
+        is_satisfied = is_satisfied && child_is_satisfied;
         if (rv) {
           return rv;
         }
         if (additive_share_from_child != 0) {
           additive_share = additive_share_from_child;
-          break;
         }
       }
       break;
 
     case node_e::THRESHOLD: {
-      std::vector<bn_t> quorum_pids;
-      quorum_pids.reserve(n);
+      std::vector<bn_t> interp_pids;
+      interp_pids.reserve(node->threshold);
       bn_t share = 0;
       bn_t share_pid = 0;
+      int satisfied_count = 0;
 
       for (int i = 0; i < n; i++) {
         bn_t share_from_child;
-        bool child_is_in_quorum = false;
-        rv = reconstruct_additive_share(q, node->children[i], quorum_names, share_from_child, child_is_in_quorum);
+        bool child_is_satisfied = false;
+        rv = reconstruct_additive_share(q, node->children[i], quorum_names, share_from_child, child_is_satisfied);
         if (rv == E_INSUFFICIENT) {
           continue;
         }
         if (rv) return rv;
 
-        if (!child_is_in_quorum) continue;
+        if (!child_is_satisfied) continue;
 
+        satisfied_count++;
         const bn_t child_pid = node->children[i]->get_pid();
-        quorum_pids.push_back(child_pid);
+        const bool child_is_selected = int(interp_pids.size()) < node->threshold;
+        if (!child_is_selected) continue;
 
+        interp_pids.push_back(child_pid);
         if (share_from_child != 0) {
           share_pid = child_pid;
           share = share_from_child;
         }
       }
 
-      if (int(quorum_pids.size()) < node->threshold) {
+      if (satisfied_count < node->threshold) {
         dylog_disable_scope_t dylog_disable_scope;
         return coinbase::error(E_INSUFFICIENT);
       }
-      is_in_quorum = true;
+      is_satisfied = true;
 
       // Target party is outside the selected quorum subtree for this threshold node.
       if (share_pid == 0) {
@@ -565,14 +568,6 @@ error_t key_share_mp_t::reconstruct_additive_share(const mod_t& q, const node_t*
         break;
       }
 
-      std::vector<bn_t> interp_pids;
-      interp_pids.reserve(node->threshold);
-      interp_pids.push_back(share_pid);
-      for (const auto& pid : quorum_pids) {
-        if (int(interp_pids.size()) == node->threshold) break;
-        if (pid == share_pid) continue;
-        interp_pids.push_back(pid);
-      }
       cb_assert(int(interp_pids.size()) == node->threshold);
 
       additive_share = crypto::lagrange_partial_interpolate(0, {share}, {share_pid}, interp_pids, q);
@@ -588,7 +583,7 @@ error_t key_share_mp_t::reconstruct_additive_share(const mod_t& q, const node_t*
 error_t key_share_mp_t::reconstruct_pub_additive_shares(const crypto::ss::node_t* node,
                                                         const std::set<crypto::pname_t>& quorum_names,
                                                         const crypto::pname_t target, ecc_point_t& pub_additive_shares,
-                                                        bool& is_in_quorum) const {
+                                                        bool& is_satisfied) const {
   error_t rv = UNINITIALIZED_ERROR;
   int n = node->get_n();
 
@@ -598,82 +593,85 @@ error_t key_share_mp_t::reconstruct_pub_additive_shares(const crypto::ss::node_t
       if (node->name == target) {
         pub_additive_shares = Qis.at(node->name);
       }
-      is_in_quorum = quorum_names.find(node->name) != quorum_names.end();
+      is_satisfied = quorum_names.find(node->name) != quorum_names.end();
     } break;
 
     case node_e::OR:
+      pub_additive_shares = curve.infinity();
+      is_satisfied = false;
       for (int i = 0; i < n; i++) {
         ecc_point_t additive_share_from_child = curve.infinity();
-        bool child_is_in_quorum = false;
+        bool child_is_satisfied = false;
         rv = reconstruct_pub_additive_shares(node->children[i], quorum_names, target, additive_share_from_child,
-                                             child_is_in_quorum);
-        is_in_quorum = is_in_quorum || child_is_in_quorum;
+                                             child_is_satisfied);
+        is_satisfied = is_satisfied || child_is_satisfied;
         if (rv == E_INSUFFICIENT) {
           rv = SUCCESS;
           continue;
         }
         if (rv) return rv;
-        if (!is_in_quorum) {
+        if (!child_is_satisfied) {
           continue;
         }
         pub_additive_shares = additive_share_from_child;
         break;
       }
-      if (rv == E_INSUFFICIENT) {
-        return coinbase::error(E_INSUFFICIENT);
-      }
       break;
     case node_e::AND:
-      is_in_quorum = true;
+      pub_additive_shares = curve.infinity();
+      is_satisfied = true;
       for (int i = 0; i < n; i++) {
         ecc_point_t additive_share_from_child = curve.infinity();
-        bool child_is_in_quorum = false;
+        bool child_is_satisfied = false;
         rv = reconstruct_pub_additive_shares(node->children[i], quorum_names, target, additive_share_from_child,
-                                             child_is_in_quorum);
-        is_in_quorum = is_in_quorum && child_is_in_quorum;
+                                             child_is_satisfied);
+        is_satisfied = is_satisfied && child_is_satisfied;
         if (rv) {
           return rv;
         }
 
         if (!additive_share_from_child.is_infinity()) {
           pub_additive_shares = additive_share_from_child;
-          break;
         }
       }
       break;
 
     case node_e::THRESHOLD: {
-      std::vector<bn_t> quorum_pids;
-      quorum_pids.reserve(n);
+      std::vector<bn_t> interp_pids;
+      interp_pids.reserve(node->threshold);
       ecc_point_t share = curve.infinity();
       bn_t share_pid = 0;
+      int satisfied_count = 0;
 
       for (int i = 0; i < n; i++) {
         ecc_point_t share_from_child = curve.infinity();
-        bool child_is_in_quorum = false;
+        bool child_is_satisfied = false;
         rv = reconstruct_pub_additive_shares(node->children[i], quorum_names, target, share_from_child,
-                                             child_is_in_quorum);
+                                             child_is_satisfied);
         if (rv == E_INSUFFICIENT) {
           continue;
         }
         if (rv) return rv;
 
-        if (!child_is_in_quorum) continue;
+        if (!child_is_satisfied) continue;
 
+        satisfied_count++;
         const bn_t child_pid = node->children[i]->get_pid();
-        quorum_pids.push_back(child_pid);
+        const bool child_is_selected = int(interp_pids.size()) < node->threshold;
+        if (!child_is_selected) continue;
 
+        interp_pids.push_back(child_pid);
         if (!share_from_child.is_infinity()) {
           share_pid = child_pid;
           share = share_from_child;
         }
       }
 
-      if (int(quorum_pids.size()) < node->threshold) {
+      if (satisfied_count < node->threshold) {
         dylog_disable_scope_t dylog_disable_scope;
         return coinbase::error(E_INSUFFICIENT);
       }
-      is_in_quorum = true;
+      is_satisfied = true;
 
       // Target party is outside the selected quorum subtree for this threshold node.
       if (share_pid == 0) {
@@ -681,14 +679,6 @@ error_t key_share_mp_t::reconstruct_pub_additive_shares(const crypto::ss::node_t
         break;
       }
 
-      std::vector<bn_t> interp_pids;
-      interp_pids.reserve(node->threshold);
-      interp_pids.push_back(share_pid);
-      for (const auto& pid : quorum_pids) {
-        if (int(interp_pids.size()) == node->threshold) break;
-        if (pid == share_pid) continue;
-        interp_pids.push_back(pid);
-      }
       cb_assert(int(interp_pids.size()) == node->threshold);
 
       pub_additive_shares = crypto::lagrange_partial_interpolate_exponent(0, {share}, {share_pid}, interp_pids);
@@ -709,17 +699,17 @@ error_t key_share_mp_t::to_additive_share(const crypto::ss::ac_t ac, const std::
   error_t rv = UNINITIALIZED_ERROR;
   const mod_t& q = curve.order();
   bn_t new_x_share;
-  bool _ignore_is_in_quorum = false;
-  if (rv = reconstruct_additive_share(q, ac.root, quorum_names, new_x_share, _ignore_is_in_quorum)) return rv;
+  bool _ignore_is_satisfied = false;
+  if (rv = reconstruct_additive_share(q, ac.root, quorum_names, new_x_share, _ignore_is_satisfied)) return rv;
 
   party_map_t<ecc_point_t> new_Qis;
   std::vector<crypto::pname_t> quorum_names_vec(quorum_names.begin(), quorum_names.end());
 
   for (size_t j = 0; j < quorum_names_vec.size(); j++) {
     crypto::vartime_scope_t vartime_scope;
-    bool _ignore_is_in_quorum = false;
+    bool _ignore_is_satisfied = false;
     ecc_point_t new_Qi;
-    if (rv = reconstruct_pub_additive_shares(ac.root, quorum_names, quorum_names_vec[j], new_Qi, _ignore_is_in_quorum))
+    if (rv = reconstruct_pub_additive_shares(ac.root, quorum_names, quorum_names_vec[j], new_Qi, _ignore_is_satisfied))
       return rv;
     new_Qis[quorum_names_vec[j]] = new_Qi;
   }

--- a/src/cbmpc/zk/zk_elgamal_com.cpp
+++ b/src/cbmpc/zk/zk_elgamal_com.cpp
@@ -218,19 +218,17 @@ void uc_elgamal_com_mult_private_scalar_t::prove(const ecc_point_t& Q, const elg
       },
 
       // hash
-      [&](uint16_t i, uint16_t e_tag) -> uint16_t {
-        return hash32bit_for_zk_fischlin(common_hash, i, e_tag, z1_tag, z2_tag);
-      },
+      [&](int i, int e_tag) -> uint32_t { return hash32bit_for_zk_fischlin(common_hash, i, e_tag, z1_tag, z2_tag); },
 
       // save
-      [&](int i, uint16_t e_tag) {
+      [&](int i, int e_tag) {
         e[i] = e_tag;
         z1[i] = z1_tag;
         z2[i] = z2_tag;
       },
 
       // response_next
-      [&](uint16_t e_tag) {
+      [&](int e_tag) {
         int res = bn_mod_add_fixed_top(z1_tag, z1_tag, c, q_value);
         cb_assert(res);
         res = bn_mod_add_fixed_top(z2_tag, z2_tag, r, q_value);
@@ -259,7 +257,7 @@ error_t uc_elgamal_com_mult_private_scalar_t::verify(const ecc_point_t& Q, const
 
   const mod_t& q = curve.order();
   const auto& G = curve.generator();
-  uint16_t b_mask = params.b_mask();
+  uint32_t b_mask = params.b_mask();
 
   for (int i = 0; i < rho; i++) {
     if (rv = curve.check(A1_tag[i]))
@@ -288,7 +286,7 @@ error_t uc_elgamal_com_mult_private_scalar_t::verify(const ecc_point_t& Q, const
     A1_sum += sigma * A1_tag[i];
     A2_sum += sigma * A2_tag[i];
 
-    uint16_t h = hash32bit_for_zk_fischlin(common_hash, uint16_t(i), e[i], z1[i], z2[i]) & b_mask;
+    uint32_t h = hash32bit_for_zk_fischlin(common_hash, i, e[i], z1[i], z2[i]) & b_mask;
     if (h != 0) return coinbase::error(E_CRYPTO);
   }
 

--- a/tests/unit/protocol/test_ec_dkg.cpp
+++ b/tests/unit/protocol/test_ec_dkg.cpp
@@ -28,6 +28,7 @@ static void RunDkgAndAdditiveShareTest(crypto::ss::node_t* root_node, const std:
   ss::ac_t ac;
   ac.curve = curve;
   ac.root = root_node;
+  ASSERT_TRUE(ac.enough_for_quorum(additive_quorum_names));
 
   mpc::party_set_t quorum_party_set;
   for (int idx : dkg_quorum_indices) quorum_party_set.add(idx);
@@ -49,16 +50,36 @@ static void RunDkgAndAdditiveShareTest(crypto::ss::node_t* root_node, const std:
   // Test to_additive_share for each member in the additive quorum
   std::map<crypto::pname_t, int> index_map;
   for (int i = 0; i < pnames.size(); i++) index_map[pnames[i]] = i;
+  bn_t additive_x_sum = 0;
+  bool has_reference_Qis = false;
+  party_map_t<ecc_point_t> reference_Qis;
   for (const auto& name : additive_quorum_names) {
     coinbase::mpc::eckey::key_share_mp_t additive_share;
     ASSERT_OK(keyshares[index_map[name]].to_additive_share(ac, additive_quorum_names, additive_share));
     EXPECT_EQ(additive_share.Q, keyshares[0].Q);
+
     for (const auto& qn : additive_quorum_names) {
       ASSERT_TRUE(additive_share.Qis.count(qn));
       EXPECT_TRUE(additive_share.Qis[qn].valid());
     }
+
+    if (!has_reference_Qis) {
+      reference_Qis = additive_share.Qis;
+      has_reference_Qis = true;
+    } else {
+      EXPECT_EQ(additive_share.Qis, reference_Qis);
+    }
+
+    MODULO(curve.order()) additive_x_sum += additive_share.x_share;
     EXPECT_EQ(additive_share.x_share * G, additive_share.Qis[name]);
   }
+
+  ecc_point_t additive_Q_sum = curve.infinity();
+  for (const auto& entry : reference_Qis) {
+    additive_Q_sum += entry.second;
+  }
+  EXPECT_EQ(additive_Q_sum, keyshares[0].Q);
+  EXPECT_EQ(additive_x_sum * G, keyshares[0].Q);
 }
 
 TEST(ECDKG, ReconstructPubAdditiveShares) {
@@ -146,6 +167,85 @@ TEST(ECDKG, ReconstructPubShares_OR) {
   RunDkgAndAdditiveShareTest(root_node, pnames, dkg_quorum_indices, additive_quorum);
 }
 
+TEST(ECDKG, ReconstructAdditiveShares_ORSkipsUnsatisfiedAND) {
+  // OR(AND(p0, p1), p2) with additive quorum {p0, p2}. The root quorum is
+  // satisfied by p2, so reconstruction must not select the unsatisfied AND.
+  ss::node_t* root_node =
+      new ss::node_t(ss::node_e::OR, "", 0,
+                     {new ss::node_t(ss::node_e::AND, "and-group", 0,
+                                     {new ss::node_t(ss::node_e::LEAF, "p0"), new ss::node_t(ss::node_e::LEAF, "p1")}),
+                      new ss::node_t(ss::node_e::LEAF, "p2")});
+
+  std::vector<crypto::pname_t> pnames = {"p0", "p1", "p2"};
+  std::set<int> dkg_quorum_indices = {0, 2};
+  std::set<crypto::pname_t> additive_quorum = {"p0", "p2"};
+  RunDkgAndAdditiveShareTest(root_node, pnames, dkg_quorum_indices, additive_quorum);
+}
+
+TEST(ECDKG, ReconstructAdditiveShares_ORWithRedundantSatisfiedLeaves) {
+  // OR(p0, p1, p2) with all leaves supplied. The first satisfied leaf is enough,
+  // and the redundant leaves should receive zero additive contribution.
+  ss::node_t* root_node =
+      new ss::node_t(ss::node_e::OR, "", 0,
+                     {new ss::node_t(ss::node_e::LEAF, "p0"), new ss::node_t(ss::node_e::LEAF, "p1"),
+                      new ss::node_t(ss::node_e::LEAF, "p2")});
+
+  std::vector<crypto::pname_t> pnames = {"p0", "p1", "p2"};
+  std::set<int> dkg_quorum_indices = {0, 1, 2};
+  std::set<crypto::pname_t> additive_quorum = {"p0", "p1", "p2"};
+  RunDkgAndAdditiveShareTest(root_node, pnames, dkg_quorum_indices, additive_quorum);
+}
+
+TEST(ECDKG, ReconstructAdditiveShares_ANDWithRedundantThresholdChild) {
+  // AND(THRESHOLD[1](p0, p1, p2), p3) with all leaves supplied. The threshold
+  // child has redundant leaves, but the AND node should still reconstruct.
+  ss::node_t* root_node =
+      new ss::node_t(ss::node_e::AND, "", 0,
+                     {new ss::node_t(ss::node_e::THRESHOLD, "inner-th", 1,
+                                     {new ss::node_t(ss::node_e::LEAF, "p0"), new ss::node_t(ss::node_e::LEAF, "p1"),
+                                      new ss::node_t(ss::node_e::LEAF, "p2")}),
+                      new ss::node_t(ss::node_e::LEAF, "p3")});
+
+  std::vector<crypto::pname_t> pnames = {"p0", "p1", "p2", "p3"};
+  std::set<int> dkg_quorum_indices = {0, 1, 2, 3};
+  std::set<crypto::pname_t> additive_quorum = {"p0", "p1", "p2", "p3"};
+  RunDkgAndAdditiveShareTest(root_node, pnames, dkg_quorum_indices, additive_quorum);
+}
+
+TEST(ECDKG, ReconstructAdditiveShares_ThresholdWithRedundantCompositeChildren) {
+  // THRESHOLD[2](OR(p0, p1), AND(p2, p3), p4) with all leaves supplied. The
+  // threshold node should select a consistent pair of satisfied children.
+  ss::node_t* root_node =
+      new ss::node_t(ss::node_e::THRESHOLD, "", 2,
+                     {new ss::node_t(ss::node_e::OR, "or-group", 0,
+                                     {new ss::node_t(ss::node_e::LEAF, "p0"), new ss::node_t(ss::node_e::LEAF, "p1")}),
+                      new ss::node_t(ss::node_e::AND, "and-group", 0,
+                                     {new ss::node_t(ss::node_e::LEAF, "p2"), new ss::node_t(ss::node_e::LEAF, "p3")}),
+                      new ss::node_t(ss::node_e::LEAF, "p4")});
+
+  std::vector<crypto::pname_t> pnames = {"p0", "p1", "p2", "p3", "p4"};
+  std::set<int> dkg_quorum_indices = {0, 1, 2, 3, 4};
+  std::set<crypto::pname_t> additive_quorum = {"p0", "p1", "p2", "p3", "p4"};
+  RunDkgAndAdditiveShareTest(root_node, pnames, dkg_quorum_indices, additive_quorum);
+}
+
+TEST(ECDKG, ReconstructAdditiveShares_ThresholdSkipsUnsatisfiedRedundantChild) {
+  // THRESHOLD[2](AND(p0, p1), OR(p2, p3), p4) with p1 absent. The unsatisfied
+  // AND child is redundant because OR(p2, p3) and p4 satisfy the threshold.
+  ss::node_t* root_node =
+      new ss::node_t(ss::node_e::THRESHOLD, "", 2,
+                     {new ss::node_t(ss::node_e::AND, "and-group", 0,
+                                     {new ss::node_t(ss::node_e::LEAF, "p0"), new ss::node_t(ss::node_e::LEAF, "p1")}),
+                      new ss::node_t(ss::node_e::OR, "or-group", 0,
+                                     {new ss::node_t(ss::node_e::LEAF, "p2"), new ss::node_t(ss::node_e::LEAF, "p3")}),
+                      new ss::node_t(ss::node_e::LEAF, "p4")});
+
+  std::vector<crypto::pname_t> pnames = {"p0", "p1", "p2", "p3", "p4"};
+  std::set<int> dkg_quorum_indices = {0, 1, 2, 3, 4};
+  std::set<crypto::pname_t> additive_quorum = {"p0", "p2", "p3", "p4"};
+  RunDkgAndAdditiveShareTest(root_node, pnames, dkg_quorum_indices, additive_quorum);
+}
+
 TEST(ECDKG, ReconstructPubShares_Thres2of3) {
   // THRESHOLD[2](p0, p1, p2) with additive quorum {p0, p2}
   ss::node_t* root_node =
@@ -199,7 +299,7 @@ TEST(ECDKG, ReconstructPub_NofN_AndEq) {
 }
 
 TEST(ECDKG, ReconstructPub_3of4_LargeLeaves) {
-  // THRESHOLD[3](p0, p1, p2, p3) with additive quorum {p0, p1, p2}
+  // THRESHOLD[3](p0, p1, p2, p3) with additive quorum {p1, p2, p3}
   ss::node_t* root_node =
       new ss::node_t(ss::node_e::THRESHOLD, "", 3,
                      {new ss::node_t(ss::node_e::LEAF, "p0"), new ss::node_t(ss::node_e::LEAF, "p1"),

--- a/tools/benchmark/bm_share.cpp
+++ b/tools/benchmark/bm_share.cpp
@@ -22,7 +22,7 @@ static void BM_ShamirShare(benchmark::State& state) {
     ss::share_threshold(q, a, m, n, pids);
   }
 }
-BENCHMARK(BM_ShamirShare)->Name("BP/Share/Shamir")->ArgsProduct({{10, 20, 30}, {2, 3, 4, 5, 6, 7}});
+BENCHMARK(BM_ShamirShare)->Name("BP/Share/Shamir")->ArgsProduct({{2, 3, 4, 5, 6, 7}, {10, 20, 30}});
 
 static void BM_HornerPoly(benchmark::State& state) {
   int n = state.range(0);


### PR DESCRIPTION
Track access-structure satisfaction separately for child nodes so OR and threshold reconstruction select only satisfied subtrees when producing additive private and public shares.

Add ECDKG coverage for redundant and partially unsatisfied composite children.

Use full-width Fischlin hash values to avoid truncating accepted parameter ranges, and correct the Shamir benchmark argument ordering.