### PR TITLE
feat: add ML-KEM-768 and extend bn256_t/DRBG/RO primitives

### DIFF
--- a/include-internal/cbmpc/internal/crypto/base.h
+++ b/include-internal/cbmpc/internal/crypto/base.h
@@ -30,6 +30,7 @@ constexpr int SEC_P_STAT_SHORT = 50;
 
 namespace coinbase::crypto {
 class bn_t;
+class bn256_t;
 class mod_t;
 class ecc_point_t;
 
@@ -125,6 +126,11 @@ class drbg_aes_ctr_t {
   bn_t gen_bn(int bits);
   bn_t gen_bn(const mod_t& mod);
   bn_t gen_bn(const bn_t& mod);
+  bits_t gen_bits(int bitlen);
+  // Optimized 256-bit sampler for four-limb moduli. For moduli very close to
+  // 2^256 it may return a raw 256-bit draw for speed, so callers must tolerate
+  // the negligible probability of a value outside the modulus.
+  bn256_t gen_bn256(const mod_t& mod);
 
   bool gen_bool() { return (gen_byte() & 1) != 0; }
   uint32_t gen_int() {

--- a/include-internal/cbmpc/internal/crypto/base_bn256.h
+++ b/include-internal/cbmpc/internal/crypto/base_bn256.h
@@ -105,6 +105,10 @@ class alignas(32) bn256_t {
 
   bool operator==(const bn256_t& b) const;
   bool operator!=(const bn256_t& b) const;
+  bool operator>(const bn256_t& b) const;
+  bool operator<(const bn256_t& b) const;
+  bool operator>=(const bn256_t& b) const;
+  bool operator<=(const bn256_t& b) const;
 
   bn256_t operator+(const bn256_t& b) const;
   bn256_t operator-(const bn256_t& b) const;
@@ -118,6 +122,10 @@ class alignas(32) bn256_t {
 
   bn256_t operator-() const;
   bn256_t inv_mod(const mod_t& q) const;
+
+  static void add_mod(bn256_t& r, const bn256_t& a, const bn256_t& b, const mod_t& mod);
+  static void sub_mod(bn256_t& r, const bn256_t& a, const bn256_t& b, const mod_t& mod);
+  static void neg_mod(bn256_t& r, const bn256_t& a, const mod_t& mod);
 
   void to_bin(byte_ptr m) const;
   buf_t to_bin() const;
@@ -133,6 +141,7 @@ class alignas(32) bn256_t {
   static void mul_add_no_reduce(uint64_t r[8], const bn256_t& a, const bn256_t& b);
   static void add_no_reduce(uint64_t r[8], const bn256_t& a);
   static bn256_t reduce(uint64_t r[8]);
+  static bn256_t reduce(uint64_t r[8], const mod_t& mod);
   static bn256_t two_to_pow(int n);
 
  private:
@@ -141,6 +150,9 @@ class alignas(32) bn256_t {
   void mont_mul(const bn256_t& a, const bn256_t& b, const uint64_t* m, uint64_t mont_prime);
   void mont_reduce(uint64_t u[8], const uint64_t* m, uint64_t mont_prime);
 };
+
+bn256_t SUM_MOD(const std::vector<bn256_t>& v, const mod_t& q);
+bn256_t SUM(const std::vector<bn256_t>& v);
 
 }  // namespace coinbase::crypto
 

--- a/include-internal/cbmpc/internal/crypto/base_ecc.h
+++ b/include-internal/cbmpc/internal/crypto/base_ecc.h
@@ -12,6 +12,7 @@ class ecc_generator_point_t;
 class ecc_pub_key_t;
 class ecc_prv_key_t;
 class ecc_point_t;
+class bn256_t;
 
 namespace secp256k1 {
 typedef struct point_t* point_ptr_t;
@@ -199,6 +200,7 @@ class ecc_point_t {
   error_t from_oct(ecurve_t curve, mem_t in) { return from_bin(curve, in); }
 
   void get_coordinates(bn_t& x, bn_t& y) const;
+  void get_coordinates(bn256_t& x, bn256_t& y) const;
   void get_x(bn_t& x) const;
   void get_y(bn_t& y) const;
 

--- a/include-internal/cbmpc/internal/crypto/base_ecc_secp256k1.h
+++ b/include-internal/cbmpc/internal/crypto/base_ecc_secp256k1.h
@@ -36,6 +36,7 @@ class ecurve_secp256k1_t final : public ecurve_interface_t {
   int to_bin(const ecc_point_t& P, byte_ptr out) const override;
   error_t from_bin(ecc_point_t& P, mem_t bin) const override;
   void get_coordinates(const ecc_point_t& P, bn_t& x, bn_t& y) const override;
+  static void get_coordinates(const std::vector<ecc_point_t>& P, std::vector<bn256_t>& x, std::vector<bn256_t>& y);
   bool hash_to_point(mem_t bin, ecc_point_t& Q) const override;
 
   buf_t pub_to_der(const ecc_pub_key_t& P) const override;

--- a/include-internal/cbmpc/internal/crypto/base_hash.h
+++ b/include-internal/cbmpc/internal/crypto/base_hash.h
@@ -13,9 +13,6 @@
 namespace coinbase::crypto {
 class bn_t;
 
-extern const uint32_t sha256_k[64];
-extern const uint64_t sha512_k[80];
-
 enum { max_hash_size = EVP_MAX_MD_SIZE };
 
 enum class hash_e {

--- a/include-internal/cbmpc/internal/crypto/mlkem768.h
+++ b/include-internal/cbmpc/internal/crypto/mlkem768.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cbmpc/internal/crypto/base.h>
+#include <cbmpc/internal/crypto/scope.h>
+
+namespace coinbase::crypto {
+
+class mlkem768_pub_key_t;
+class mlkem768_prv_key_t;
+
+class mlkem768_pub_key_t {
+  friend class mlkem768_prv_key_t;
+
+ public:
+  void encapsulate(buf_t& secret, buf_t& encapsulated) const;
+  void encapsulate(mem_t seed, buf_t& secret, buf_t& encapsulated) const;
+
+ private:
+  scoped_ptr_t<EVP_PKEY> pkey;
+};
+
+class mlkem768_prv_key_t {
+  friend class mlkem768_pub_key_t;
+
+ public:
+  void generate();
+  mlkem768_pub_key_t pub() const;
+  error_t decapsulate(mem_t encapsulated, buf_t& secret) const;
+
+ private:
+  scoped_ptr_t<EVP_PKEY> pkey;
+};
+
+}  // namespace coinbase::crypto

--- a/include-internal/cbmpc/internal/crypto/ro.h
+++ b/include-internal/cbmpc/internal/crypto/ro.h
@@ -91,6 +91,10 @@ class hash_number_t : public hmac_state_t {
   }
 
   bn_t mod(const mod_t& q);
+  // Convenience helper for deterministic non-cryptographic choices. This uses
+  // a 64-bit draw followed by `% m`, so it has modulo bias and must not be used
+  // for cryptographic challenge or scalar sampling.
+  int mod(int m);
 };
 
 /**
@@ -157,6 +161,8 @@ hash_curve_t hash_curve(const ARGS&... args) {
 
 buf_t drbg_sample_string(mem_t seed, int bits);
 bn_t drbg_sample_number(mem_t seed, const mod_t& p);  // modulo p
+// Deterministic non-cryptographic sampler; biased by `% m`.
+int drbg_sample_number(mem_t seed, int m);  // modulo m
 ecc_point_t drbg_sample_curve(mem_t seed, const crypto::ecurve_t& curve);
 
 }  // namespace coinbase::crypto::ro

--- a/src/cbmpc/core/buf.cpp
+++ b/src/cbmpc/core/buf.cpp
@@ -531,7 +531,7 @@ void bits_t::convert(converter_t& converter) {
   int size = coinbase::bits_to_bytes(count);
 
   if (converter.is_write()) {
-    if (!converter.is_calc_size()) {
+    if (size && !converter.is_calc_size()) {
       bzero_unused();
       memmove(converter.current(), data, size);
     }
@@ -541,7 +541,7 @@ void bits_t::convert(converter_t& converter) {
       return;
     }
     alloc(count);
-    memmove(data, converter.current(), size);
+    if (size) memmove(data, converter.current(), size);
   }
   converter.forward(size);
 }

--- a/src/cbmpc/crypto/CMakeLists.txt
+++ b/src/cbmpc/crypto/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(cbmpc_crypto  PRIVATE
   secret_sharing.cpp
 
   tdh2.cpp
+  mlkem768.cpp
 )
 
 target_link_libraries(cbmpc_crypto cbmpc_core)

--- a/src/cbmpc/crypto/base_bn256.cpp
+++ b/src/cbmpc/crypto/base_bn256.cpp
@@ -825,6 +825,19 @@ bool bn256_t::operator!=(uint64_t b) const {
   return x != 0;
 }
 
+bool bn256_t::operator<(const bn256_t& b) const {
+  uint64_t borrow = 0;
+  subx(w0, b.w0, borrow);
+  subx(w1, b.w1, borrow);
+  subx(w2, b.w2, borrow);
+  subx(w3, b.w3, borrow);
+  return borrow;
+}
+
+bool bn256_t::operator>=(const bn256_t& b) const { return !(*this < b); }
+bool bn256_t::operator>(const bn256_t& b) const { return b < *this; }
+bool bn256_t::operator<=(const bn256_t& b) const { return !(b < *this); }
+
 bn256_t bn256_t::two_to_pow(int n) {
   cb_assert(n >= 0 && n < 256);
   bn256_t r;
@@ -842,9 +855,29 @@ bn256_t bn256_t::two_to_pow(int n) {
 bn256_t bn256_t::operator+(const bn256_t& b) const {
   const mod_t* mod = thread_local_storage_mod();
   cb_assert(mod);
-  const auto m = mod->value().val.d;
   bn256_t r;
-  const bn256_t& a = *this;
+  add_mod(r, *this, b, *mod);
+  return r;
+}
+
+bn256_t bn256_t::operator-(const bn256_t& b) const {
+  const mod_t* mod = thread_local_storage_mod();
+  cb_assert(mod);
+  bn256_t r;
+  sub_mod(r, *this, b, *mod);
+  return r;
+}
+
+bn256_t bn256_t::operator-() const {
+  const mod_t* mod = thread_local_storage_mod();
+  cb_assert(mod);
+  bn256_t r;
+  neg_mod(r, *this, *mod);
+  return r;
+}
+
+void bn256_t::add_mod(bn256_t& r, const bn256_t& a, const bn256_t& b, const mod_t& mod) {
+  const auto m = mod.value().val.d;
 
   uint64_t carry = 0;
   uint64_t a0 = addx(a.w0, b.w0, carry);
@@ -859,20 +892,15 @@ bn256_t bn256_t::operator+(const bn256_t& b) const {
   uint64_t s3 = subx(a3, m[3], borrow);
 
   subx(carry, 0, borrow);
-  uint64_t mask = -uint64_t(bool(borrow));
+  uint64_t mask = -borrow;
   r.w0 = s0 ^ ((a0 ^ s0) & mask);
   r.w1 = s1 ^ ((a1 ^ s1) & mask);
   r.w2 = s2 ^ ((a2 ^ s2) & mask);
   r.w3 = s3 ^ ((a3 ^ s3) & mask);
-  return r;
 }
 
-bn256_t bn256_t::operator-(const bn256_t& b) const {
-  const mod_t* mod = thread_local_storage_mod();
-  cb_assert(mod);
-  const auto m = mod->value().val.d;
-  bn256_t r;
-  const bn256_t& a = *this;
+void bn256_t::sub_mod(bn256_t& r, const bn256_t& a, const bn256_t& b, const mod_t& mod) {
+  const auto m = mod.value().val.d;
 
   uint64_t borrow = 0;
   uint64_t s0 = subx(a.w0, b.w0, borrow);
@@ -880,7 +908,7 @@ bn256_t bn256_t::operator-(const bn256_t& b) const {
   uint64_t s2 = subx(a.w2, b.w2, borrow);
   uint64_t s3 = subx(a.w3, b.w3, borrow);
 
-  uint64_t mask = -uint64_t(bool(borrow));
+  uint64_t mask = -borrow;
   uint64_t t0 = m[0] & mask;
   uint64_t t1 = m[1] & mask;
   uint64_t t2 = m[2] & mask;
@@ -891,23 +919,18 @@ bn256_t bn256_t::operator-(const bn256_t& b) const {
   r.w1 = addx(s1, t1, carry);
   r.w2 = addx(s2, t2, carry);
   r.w3 = addx(s3, t3, carry);
-  return r;
 }
 
-bn256_t bn256_t::operator-() const {
-  const mod_t* mod = thread_local_storage_mod();
-  cb_assert(mod);
-  const auto m = mod->value().val.d;
-  bn256_t r;
-  const bn256_t& b = *this;
+void bn256_t::neg_mod(bn256_t& r, const bn256_t& a, const mod_t& mod) {
+  const auto m = mod.value().val.d;
 
   uint64_t borrow = 0;
-  uint64_t s0 = subx(0, b.w0, borrow);
-  uint64_t s1 = subx(0, b.w1, borrow);
-  uint64_t s2 = subx(0, b.w2, borrow);
-  uint64_t s3 = subx(0, b.w3, borrow);
+  uint64_t s0 = subx(0, a.w0, borrow);
+  uint64_t s1 = subx(0, a.w1, borrow);
+  uint64_t s2 = subx(0, a.w2, borrow);
+  uint64_t s3 = subx(0, a.w3, borrow);
 
-  uint64_t mask = -uint64_t(borrow);
+  uint64_t mask = -borrow;
   uint64_t t0 = m[0] & mask;
   uint64_t t1 = m[1] & mask;
   uint64_t t2 = m[2] & mask;
@@ -918,7 +941,6 @@ bn256_t bn256_t::operator-() const {
   r.w1 = addx(s1, t1, carry);
   r.w2 = addx(s2, t2, carry);
   r.w3 = addx(s3, t3, carry);
-  return r;
 }
 
 bn256_t& bn256_t::operator+=(const bn256_t& b) { return *this = *this + b; }
@@ -1096,8 +1118,17 @@ void bn256_t::mul_add_no_reduce(uint64_t r[8], const bn256_t& a, const bn256_t& 
 bn256_t bn256_t::reduce(uint64_t x[8]) {
   const mod_t* mod = thread_local_storage_mod();
   cb_assert(mod);
-  const auto m = mod->value().val.d;
-  const auto mu = mod->get_barrett_mu().val.d;
+  return reduce(x, *mod);
+}
+
+bn256_t bn256_t::reduce(uint64_t x[8], const mod_t& mod) {
+  const auto& m_val = mod.value().val;
+  const auto& mu_val = mod.get_barrett_mu().val;
+  cb_assert(m_val.top == 4);
+  cb_assert(mu_val.top == 5);
+
+  const auto m = m_val.d;
+  const auto mu = mu_val.d;
 
   bn256_t r;
   r.barrett_reduce(x, (const uint64_t*)m, (const uint64_t*)mu);
@@ -1369,6 +1400,21 @@ bn256_t bn256_t::mont_mul(const bn256_t& a, const bn256_t& b) {
   bn256_t r;
   r.mont_mul(a, b, (const uint64_t*)m, prime);
   return r;
+}
+
+bn256_t SUM_MOD(const std::vector<bn256_t>& v, const mod_t& q) {
+  bn256_t s;
+  if (!v.empty()) {
+    s = v[0];
+    for (int i = 1; i < int(v.size()); i++) bn256_t::add_mod(s, s, v[i], q);
+  }
+  return s;
+}
+
+bn256_t SUM(const std::vector<bn256_t>& v) {
+  const mod_t* mod = thread_local_storage_mod();
+  cb_assert(mod);
+  return SUM_MOD(v, *mod);
 }
 
 }  // namespace coinbase::crypto

--- a/src/cbmpc/crypto/base_ecc.cpp
+++ b/src/cbmpc/crypto/base_ecc.cpp
@@ -1,5 +1,6 @@
 #include <cbmpc/internal/core/log.h>
 #include <cbmpc/internal/crypto/base.h>
+#include <cbmpc/internal/crypto/base_bn256.h>
 #include <cbmpc/internal/crypto/base_ecc_secp256k1.h>
 #include <cbmpc/internal/crypto/base_eddsa.h>
 #include <cbmpc/internal/crypto/base_pki.h>
@@ -761,6 +762,13 @@ void ecc_point_t::convert_fixed_curve(coinbase::converter_t& converter, ecurve_t
 }
 
 void ecc_point_t::get_coordinates(bn_t& x, bn_t& y) const { curve.ptr->get_coordinates(*this, x, y); }
+
+void ecc_point_t::get_coordinates(bn256_t& x, bn256_t& y) const {
+  bn_t _x, _y;
+  get_coordinates(_x, _y);
+  x = _x;
+  y = _y;
+}
 
 bn_t ecc_point_t::get_x() const {
   bn_t x;

--- a/src/cbmpc/crypto/base_ecc_secp256k1.cpp
+++ b/src/cbmpc/crypto/base_ecc_secp256k1.cpp
@@ -1,3 +1,4 @@
+#include <cbmpc/internal/crypto/base_bn256.h>
 #include <cbmpc/internal/crypto/base_ecc_secp256k1.h>
 
 // clang-format off
@@ -285,6 +286,36 @@ void ecurve_secp256k1_t::get_coordinates(const ecc_point_t& P, bn_t& x, bn_t& y)
   to_bin(P, buf.data());
   x = bn_t::from_bin(buf.range(1, 32));
   y = bn_t::from_bin(buf.range(33, 32));
+}
+
+void ecurve_secp256k1_t::get_coordinates(const std::vector<ecc_point_t>& P, std::vector<bn256_t>& x,
+                                         std::vector<bn256_t>& y) {
+  int n = int(P.size());
+  if (n == 0) {
+    x.clear();
+    y.clear();
+    return;
+  }
+
+  std::vector<secp256k1_gej> gej(n);
+  std::vector<secp256k1_ge> ge(n);
+  for (int i = 0; i < n; i++) {
+    cb_assert(P[i].valid());
+    cb_assert(P[i].get_curve() == curve_secp256k1);
+    gej[i] = *(const secp256k1_gej*)P[i].secp256k1;
+  }
+  secp256k1_ge_set_all_gej_var(ge.data(), gej.data(), n);
+  x.resize(n);
+  y.resize(n);
+  for (int i = 0; i < n; i++) {
+    uint8_t bin[32];
+    secp256k1_fe_normalize_var(&ge[i].x);
+    secp256k1_fe_get_b32(bin, &ge[i].x);
+    x[i] = bn256_t::from_bin(mem_t(bin, 32));
+    secp256k1_fe_normalize_var(&ge[i].y);
+    secp256k1_fe_get_b32(bin, &ge[i].y);
+    y[i] = bn256_t::from_bin(mem_t(bin, 32));
+  }
 }
 
 bool ecurve_secp256k1_t::hash_to_point(mem_t bin, ecc_point_t& Q) const {

--- a/src/cbmpc/crypto/drbg.cpp
+++ b/src/cbmpc/crypto/drbg.cpp
@@ -1,4 +1,5 @@
 #include <cbmpc/internal/crypto/base.h>
+#include <cbmpc/internal/crypto/base_bn256.h>
 
 namespace coinbase::crypto {
 
@@ -44,6 +45,40 @@ bn_t drbg_aes_ctr_t::gen_bn(int bits) {
   int n = coinbase::bits_to_bytes(bits);
   buf_t bin = gen(n);
   return bn_t::from_bin_bitlen(bin, bits);
+}
+
+bits_t drbg_aes_ctr_t::gen_bits(int bitlen) {
+  bits_t bits(bitlen);
+  gen(mem_t(bits));
+  return bits;
+}
+
+bn256_t drbg_aes_ctr_t::gen_bn256(const mod_t& mod) {
+  bn256_t r;
+
+  const bn_t& m = mod;
+  const BIGNUM* mbn = m;
+  if (mbn->top == 4 && mbn->d[3] == 0xffffffffffffffff && mbn->d[2] >= 0xffffffffffff0000) {
+    // Fast path for near-2^256 moduli. This intentionally skips reduction for
+    // speed; callers of gen_bn256 must tolerate the negligible chance that the
+    // result is >= mod.
+    byte_t rnd[32];
+    gen(byte_ptr(rnd), sizeof(rnd));
+    r = bn256_t::from_bin(mem_t(rnd, sizeof(rnd)));
+    return r;
+  }
+
+  byte_t rnd[40];
+  gen(byte_ptr(rnd), sizeof(rnd));
+
+  uint64_t temp[8] = {0};
+  temp[0] = coinbase::be_get_8(rnd + 32);
+  temp[1] = coinbase::be_get_8(rnd + 24);
+  temp[2] = coinbase::be_get_8(rnd + 16);
+  temp[3] = coinbase::be_get_8(rnd + 8);
+  temp[4] = coinbase::be_get_8(rnd + 0);
+  r = bn256_t::reduce(temp, mod);
+  return r;
 }
 
 }  // namespace coinbase::crypto

--- a/src/cbmpc/crypto/mlkem768.cpp
+++ b/src/cbmpc/crypto/mlkem768.cpp
@@ -1,0 +1,92 @@
+#include <openssl/core_names.h>
+
+#include <cbmpc/internal/crypto/mlkem768.h>
+
+namespace coinbase::crypto {
+
+void mlkem768_prv_key_t::generate() {
+  scoped_ptr_t<EVP_PKEY_CTX> ctx = EVP_PKEY_CTX_new_from_name(NULL, "ML-KEM-768", NULL);
+  cb_assert(ctx);
+  auto res = EVP_PKEY_keygen_init(ctx);
+  cb_assert(res > 0);
+  EVP_PKEY* pk = nullptr;
+  res = EVP_PKEY_keygen(ctx, &pk);
+  cb_assert(res > 0);
+  pkey = pk;
+}
+
+mlkem768_pub_key_t mlkem768_prv_key_t::pub() const {
+  scoped_ptr_t<EVP_PKEY_CTX> ctx = EVP_PKEY_CTX_new(pkey, NULL);
+  cb_assert(ctx);
+  auto res = EVP_PKEY_fromdata_init(ctx);
+  cb_assert(res > 0);
+
+  OSSL_PARAM* params = NULL;
+  res = EVP_PKEY_todata(pkey, EVP_PKEY_PUBLIC_KEY, &params);
+  cb_assert(res > 0);
+  EVP_PKEY* pk = nullptr;
+  res = EVP_PKEY_fromdata(ctx, &pk, EVP_PKEY_PUBLIC_KEY, params);
+  cb_assert(res > 0);
+  OSSL_PARAM_free(params);
+
+  mlkem768_pub_key_t p;
+  p.pkey = pk;
+  return p;
+}
+
+void mlkem768_pub_key_t::encapsulate(buf_t& secret, buf_t& encapsulated) const {
+  scoped_ptr_t<EVP_PKEY_CTX> ctx = EVP_PKEY_CTX_new(pkey, NULL);
+  cb_assert(ctx);
+  auto res = EVP_PKEY_encapsulate_init(ctx, NULL);
+  cb_assert(res > 0);
+
+  size_t secret_len, encapsulated_len;
+  res = EVP_PKEY_encapsulate(ctx, NULL, &encapsulated_len, NULL, &secret_len);
+  cb_assert(res > 0);
+  secret.resize(int(secret_len));
+  encapsulated.resize(int(encapsulated_len));
+
+  res = EVP_PKEY_encapsulate(ctx, encapsulated.data(), &encapsulated_len, secret.data(), &secret_len);
+  cb_assert(res > 0);
+}
+
+void mlkem768_pub_key_t::encapsulate(mem_t seed, buf_t& secret, buf_t& encapsulated) const {
+  cb_assert(seed.size >= 32);
+  scoped_ptr_t<EVP_PKEY_CTX> ctx = EVP_PKEY_CTX_new(pkey, NULL);
+  cb_assert(ctx);
+  auto res = EVP_PKEY_encapsulate_init(ctx, NULL);
+  cb_assert(res > 0);
+
+  OSSL_PARAM params[2];
+  params[0] = OSSL_PARAM_construct_octet_string(OSSL_KEM_PARAM_IKME, byte_ptr(seed.data), seed.size);
+  params[1] = OSSL_PARAM_construct_end();
+  cb_assert(0 < EVP_PKEY_CTX_set_params(ctx, params));
+
+  size_t secret_len, encapsulated_len;
+  res = EVP_PKEY_encapsulate(ctx, NULL, &encapsulated_len, NULL, &secret_len);
+  cb_assert(res > 0);
+  secret.resize(int(secret_len));
+  encapsulated.resize(int(encapsulated_len));
+
+  res = EVP_PKEY_encapsulate(ctx, encapsulated.data(), &encapsulated_len, secret.data(), &secret_len);
+  cb_assert(res > 0);
+}
+
+error_t mlkem768_prv_key_t::decapsulate(mem_t encapsulated, buf_t& secret) const {
+  scoped_ptr_t<EVP_PKEY_CTX> ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
+  cb_assert(ctx);
+  auto res = EVP_PKEY_decapsulate_init(ctx, NULL);
+  cb_assert(res > 0);
+
+  size_t secret_len = 0;
+  if (0 >= EVP_PKEY_decapsulate(ctx, NULL, &secret_len, encapsulated.data, encapsulated.size))
+    return coinbase::error(E_CRYPTO);
+  secret.resize(int(secret_len));
+  if (0 >= EVP_PKEY_decapsulate(ctx, secret.data(), &secret_len, encapsulated.data, encapsulated.size)) {
+    secret.free();
+    return coinbase::error(E_CRYPTO);
+  }
+  return 0;
+}
+
+}  // namespace coinbase::crypto

--- a/src/cbmpc/crypto/ro.cpp
+++ b/src/cbmpc/crypto/ro.cpp
@@ -24,6 +24,15 @@ bn_t drbg_sample_number(mem_t seed, const mod_t& p)  // modulo p
   return bn_t::from_bin(r) % p;
 }
 
+int drbg_sample_number(mem_t seed, int m)  // modulo m
+{
+  cb_assert(m > 0);
+  // Used only for deterministic non-cryptographic choices. The `% m` mapping
+  // is biased, so cryptographic challenge/scalar sampling should use mod_t.
+  buf_t r = drbg_sample_string(seed, 64);
+  return coinbase::be_get_8(r.data()) % m;
+}
+
 /**
  * @specs:
  * - basic-primitives-spec | drbg-sample-curve-point-1P
@@ -74,6 +83,11 @@ buf_t hash_string_t::bitlen(int bits) {
 bn_t hash_number_t::mod(const mod_t& p) {
   buf_t h = final();
   return drbg_sample_number(h, p);
+}
+
+int hash_number_t::mod(int m) {
+  buf_t h = final();
+  return drbg_sample_number(h, m);
 }
 
 std::vector<bn_t> hash_numbers_t::mod(const mod_t& p) {

--- a/tests/unit/core/test_convert.cpp
+++ b/tests/unit/core/test_convert.cpp
@@ -122,6 +122,16 @@ TEST(CoreConvert, CustomStruct) {
   EXPECT_EQ(out.s, "");
 }
 
+TEST(CoreConvert, EmptyBitsRoundTrip) {
+  bits_t in;
+  buf_t buf = coinbase::ser(in);
+
+  bits_t out;
+  EXPECT_OK(deser(buf, out));
+  EXPECT_TRUE(out.empty());
+  EXPECT_EQ(out.count(), 0);
+}
+
 TEST(CoreConvert, ConvertLenRejectsOversizedLengths) {
   // Encode a 4-byte length prefix > converter_t::MAX_CONVERT_LEN (64 MiB).
   // len = 0x04000001 -> bytes: 0xE4 0x00 0x00 0x01

--- a/tests/unit/crypto/test_base_ecc.cpp
+++ b/tests/unit/crypto/test_base_ecc.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <cbmpc/internal/crypto/base.h>
+#include <cbmpc/internal/crypto/base_bn256.h>
+#include <cbmpc/internal/crypto/base_ecc_secp256k1.h>
 #include <cbmpc/internal/crypto/base_pki.h>
 
 #include "utils/test_macros.h"
@@ -70,6 +72,29 @@ TEST_F(ECC, secp256k1) {
       EXPECT_TRUE(((q - 1) * C + C).is_infinity());
     }
   }
+}
+
+TEST_F(ECC, secp256k1_batch_get_coordinates) {
+  std::vector<ecc_point_t> points;
+  for (int i = 1; i <= 8; ++i) points.push_back(bn_t(i) * curve_secp256k1.generator());
+
+  std::vector<bn256_t> xs, ys;
+  ecurve_secp256k1_t::get_coordinates(points, xs, ys);
+
+  ASSERT_EQ(xs.size(), points.size());
+  ASSERT_EQ(ys.size(), points.size());
+  for (size_t i = 0; i < points.size(); ++i) {
+    bn_t x, y;
+    points[i].get_coordinates(x, y);
+    EXPECT_EQ(xs[i], bn256_t(x));
+    EXPECT_EQ(ys[i], bn256_t(y));
+  }
+}
+
+TEST_F(ECC, secp256k1_batch_get_coordinates_rejects_wrong_curve) {
+  std::vector<ecc_point_t> points = {ecc_point_t(curve_p256.generator())};
+  std::vector<bn256_t> xs, ys;
+  EXPECT_CB_ASSERT(ecurve_secp256k1_t::get_coordinates(points, xs, ys), "curve_secp256k1");
 }
 
 TEST_F(ECC, SigningScheme2) {

--- a/tests/unit/crypto/test_mlkem768.cpp
+++ b/tests/unit/crypto/test_mlkem768.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include <cbmpc/internal/crypto/base.h>
+#include <cbmpc/internal/crypto/mlkem768.h>
+
+#include "utils/test_macros.h"
+
+namespace {
+
+using namespace coinbase::crypto;
+using coinbase::buf_t;
+
+TEST(MLKEM768, PubRejectsUninitializedPrivateKey) {
+  mlkem768_prv_key_t prv_key;
+  EXPECT_CB_ASSERT(prv_key.pub(), "ctx");
+}
+
+TEST(MLKEM768, EncapsulateDecapsulateRoundTrip) {
+  mlkem768_prv_key_t prv_key;
+  prv_key.generate();
+  mlkem768_pub_key_t pub_key = prv_key.pub();
+
+  buf_t shared_secret_enc;
+  buf_t encapsulated;
+  pub_key.encapsulate(shared_secret_enc, encapsulated);
+
+  buf_t shared_secret_dec;
+  EXPECT_OK(prv_key.decapsulate(encapsulated, shared_secret_dec));
+  EXPECT_FALSE(shared_secret_enc.empty());
+  EXPECT_FALSE(encapsulated.empty());
+  EXPECT_EQ(shared_secret_enc, shared_secret_dec);
+}
+
+TEST(MLKEM768, SeededEncapsulationIsDeterministic) {
+  mlkem768_prv_key_t prv_key;
+  prv_key.generate();
+  mlkem768_pub_key_t pub_key = prv_key.pub();
+  buf_t seed = gen_random(32);
+
+  buf_t shared_secret_1, shared_secret_2;
+  buf_t encapsulated_1, encapsulated_2;
+  pub_key.encapsulate(seed, shared_secret_1, encapsulated_1);
+  pub_key.encapsulate(seed, shared_secret_2, encapsulated_2);
+
+  EXPECT_EQ(shared_secret_1, shared_secret_2);
+  EXPECT_EQ(encapsulated_1, encapsulated_2);
+
+  buf_t shared_secret_dec;
+  EXPECT_OK(prv_key.decapsulate(encapsulated_1, shared_secret_dec));
+  EXPECT_EQ(shared_secret_1, shared_secret_dec);
+}
+
+}  // namespace

--- a/tests/unit/crypto/test_ro.cpp
+++ b/tests/unit/crypto/test_ro.cpp
@@ -4,6 +4,8 @@
 #include <cbmpc/internal/crypto/base_bn256.h>
 #include <cbmpc/internal/crypto/ro.h>
 
+#include "utils/test_macros.h"
+
 using namespace coinbase::crypto;
 
 namespace {
@@ -86,3 +88,8 @@ TEST(RandomOracle, HashNumbersMod256RejectsModuliWiderThan256Bits) {
 }
 
 }  // namespace
+TEST(RandomOracle, DrbgSampleNumberRejectsNonPositiveModulus) {
+  buf_t seed = buf_t("0123456789abcdef");
+  EXPECT_CB_ASSERT(ro::drbg_sample_number(seed, 0), "m > 0");
+  EXPECT_CB_ASSERT(ro::drbg_sample_number(seed, -7), "m > 0");
+}


### PR DESCRIPTION
- Add mlkem768_pub_key_t and mlkem768_prv_key_t backed by OpenSSL ML-KEM-768 for post-quantum key encapsulation, with unit tests
- Extend bn256_t with comparison operators (<, >, <=, >=), static modular helpers (add_mod, sub_mod, neg_mod), a generic reduce(mod) overload, and SUM / SUM_MOD free functions; refactor operator+/- to delegate to statics
- Add drbg_aes_ctr_t::gen_bits and gen_bn256 with a fast path for near-2^256 moduli; add ecc_point_t::get_coordinates(bn256_t&, bn256_t&) overload
- Add hash_number_t::mod(int) and drbg_sample_number(seed, int) for deterministic non-cryptographic integer sampling (documented as biased)