### PR TITLE
fix: bound modulus buffers and OpenSSL install paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,6 @@ submodules:
 openssl-linux:
 	@echo "Building custom OpenSSL for Linux..."
 	${RUN_CMD} 'bash ./scripts/openssl/build-static-openssl-linux.sh'
-	${RUN_CMD} 'mkdir -p /usr/local/lib64'
-	${RUN_CMD} 'mkdir -p /usr/local/lib'
-	${RUN_CMD} 'mkdir -p /usr/local/include'
 
 .PHONY: openssl-macos
 openssl-macos:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ There are three build modes available:
 - **Test**: This mode enables security checks and validations to ensure the code is robust and secure.
 - **Release**: This mode applies the highest level of optimization for maximum performance and disables checks to improve runtime efficiency.
 
-## On macOS
+## Native Builds
 
 ### OpenSSL
 
@@ -176,12 +176,15 @@ The library depends on a **custom build of OpenSSL 3.6.1** with specific modific
 make openssl
 
 # Or use platform-specific targets:
+make openssl-linux      # for Linux
 make openssl-macos      # for x86_64
 make openssl-macos-m1   # for ARM64 (Apple Silicon)
 ```
 
 **Manual Build:**
 ```bash
+scripts/openssl/build-static-openssl-linux.sh      # for Linux
+# or
 scripts/openssl/build-static-openssl-macos.sh      # for x86_64
 # or
 scripts/openssl/build-static-openssl-macos-m1.sh   # for ARM64
@@ -193,10 +196,13 @@ scripts/openssl/build-static-openssl-macos-m1.sh   # for ARM64
 If you prefer a different installation path, you can set the `CBMPC_OPENSSL_ROOT` variable:
 
 ```bash
-# Option 1: Environment variable (before running cmake)
+# Option 1: Environment variable (before building OpenSSL)
+CBMPC_OPENSSL_ROOT=/your/custom/path make openssl
+
+# Option 2: Environment variable (before running cmake)
 export CBMPC_OPENSSL_ROOT=/your/custom/path
 
-# Option 2: CMake variable
+# Option 3: CMake variable
 cmake -DCBMPC_OPENSSL_ROOT=/your/custom/path ...
 ```
 

--- a/include-internal/cbmpc/internal/crypto/base_mod.h
+++ b/include-internal/cbmpc/internal/crypto/base_mod.h
@@ -20,6 +20,8 @@ bool is_vartime_scope();
 
 class mod_t {
  public:
+  inline static constexpr int MAX_MODULUS_BITS = 8192;
+
   mod_t();
   ~mod_t();
 

--- a/scripts/openssl/build-static-openssl-linux.sh
+++ b/scripts/openssl/build-static-openssl-linux.sh
@@ -29,7 +29,7 @@ sed -i -e 's/^static//' crypto/ec/curve25519.c
   no-gost no-http no-idea no-mdc2 no-md2 no-md4 no-module no-nextprotoneg no-ocb no-ocsp no-psk no-padlockeng no-poly1305 \
   no-quic no-rc2 no-rc4 no-rc5 no-rfc3779 no-scrypt no-sctp no-seed no-siphash no-sm2 no-sm3 no-sm4 no-sock no-srtp no-srp \
   no-ssl-trace no-ssl3 no-stdio no-tests no-tls no-ts no-unit-test no-uplink no-whirlpool no-zlib \
-  --prefix=/usr/local/opt/openssl@3.6.1 --libdir=lib64
+  --prefix="${CBMPC_OPENSSL_ROOT:-/usr/local/opt/openssl@3.6.1}" --libdir=lib64
 
 make build_generated install_sw -j4
 

--- a/scripts/openssl/build-static-openssl-macos-m1.sh
+++ b/scripts/openssl/build-static-openssl-macos-m1.sh
@@ -45,7 +45,7 @@ sed -i -e 's/^static//' crypto/ec/curve25519.c
   no-gost no-http no-idea no-mdc2 no-md2 no-md4 no-module no-nextprotoneg no-ocb no-ocsp no-psk no-padlockeng no-poly1305 \
   no-quic no-rc2 no-rc4 no-rc5 no-rfc3779 no-scrypt no-sctp no-seed no-siphash no-sm2 no-sm3 no-sm4 no-sock no-srtp no-srp \
   no-ssl-trace no-ssl3 no-stdio no-tests no-tls no-ts no-unit-test no-uplink no-whirlpool no-zlib \
-  --prefix=/usr/local/opt/openssl@3.6.1 darwin64-arm64-cc
+  --prefix="${CBMPC_OPENSSL_ROOT:-/usr/local/opt/openssl@3.6.1}" darwin64-arm64-cc
 
 make -j
 make install_sw

--- a/scripts/openssl/build-static-openssl-macos.sh
+++ b/scripts/openssl/build-static-openssl-macos.sh
@@ -44,7 +44,7 @@ sed -i -e 's/^static//' crypto/ec/curve25519.c
   no-gost no-http no-idea no-mdc2 no-md2 no-md4 no-module no-nextprotoneg no-ocb no-ocsp no-psk no-padlockeng no-poly1305 \
   no-quic no-rc2 no-rc4 no-rc5 no-rfc3779 no-scrypt no-sctp no-seed no-siphash no-sm2 no-sm3 no-sm4 no-sock no-srtp no-srp \
   no-ssl-trace no-ssl3 no-stdio no-tests no-tls no-ts no-unit-test no-uplink no-whirlpool no-zlib \
-  --prefix=/usr/local/opt/openssl@3.6.1 darwin64-x86_64-cc
+  --prefix="${CBMPC_OPENSSL_ROOT:-/usr/local/opt/openssl@3.6.1}" darwin64-x86_64-cc
 
 make -j
 make install_sw

--- a/src/cbmpc/crypto/base_mod.cpp
+++ b/src/cbmpc/crypto/base_mod.cpp
@@ -16,7 +16,7 @@ mod_t::~mod_t() {
   if (mont) BN_MONT_CTX_free(mont);
 }
 
-bool mod_t::is_valid_modulus(const bn_t& m) { return m > 1 && m.is_odd(); }
+bool mod_t::is_valid_modulus(const bn_t& m) { return m > 1 && m.get_bits_count() <= MAX_MODULUS_BITS && m.is_odd(); }
 
 void mod_t::convert(coinbase::converter_t& converter) {
   converter.convert(m);
@@ -147,6 +147,9 @@ static void bn_copy(BIGNUM r, BIGNUM a) {
   if (r.top > len) std::fill(r.d + len, r.d + r.top, 0);
 }
 
+enum { BN_ULONG_BITS = sizeof(BN_ULONG) * 8 };
+static constexpr int MAX_MODULUS_WORDS = (mod_t::MAX_MODULUS_BITS + BN_ULONG_BITS - 1) / BN_ULONG_BITS;
+
 void mod_t::_mul(bn_t& r, const bn_t& a, const bn_t& b) const {
   if (vartime_scope) {
     int res = BN_mod_mul(r, a, b, m, bn_t::thread_local_storage_bn_ctx());
@@ -159,6 +162,14 @@ void mod_t::_mul(bn_t& r, const bn_t& a, const bn_t& b) const {
 
   const BIGNUM& aa = *(const BIGNUM*)a;
   const BIGNUM& bb = *(const BIGNUM*)b;
+  if (aa.top == 0 || bb.top == 0) {
+    r = 0;
+    return;
+  }
+
+  cb_assert(aa.top >= 0 && bb.top >= 0 && aa.top + bb.top <= 2 * MAX_MODULUS_WORDS);
+  // Intentional bounded VLA: modulus size is capped by MAX_MODULUS_BITS.
+  // Keep this on the stack to avoid heap allocation in the modular multiplication hot path.
   BN_ULONG buf[aa.top + bb.top];
   bn_mul_normal(buf, aa.d, aa.top, bb.d, bb.top);
 
@@ -167,8 +178,6 @@ void mod_t::_mul(bn_t& r, const bn_t& a, const bn_t& b) const {
 }
 
 bn_t mod_t::div(const bn_t& a, const bn_t& b) const { return mul(a, inv(b)); }
-
-enum { BN_ULONG_BITS = sizeof(BN_ULONG) * 8 };
 
 static BN_ULONG div_words_by_two(int n, BN_ULONG* r) {
   uint64_t carry = 0;
@@ -215,22 +224,28 @@ static BN_ULONG ct_bn_sub_words(BN_ULONG* r, const BN_ULONG* a, const BN_ULONG* 
 }
 
 static BN_ULONG cnd_add_words(int n, BN_ULONG r[], bool flag, const BN_ULONG a[]) {
+  cb_assert(n > 0 && n <= MAX_MODULUS_WORDS);
   BN_ULONG mask = constant_time_mask_ulong(flag);
+  // Intentional bounded VLA: preserving the temp array keeps ct_bn_add_words()'s carry chain optimizable.
   BN_ULONG temp[n];
   for (int i = 0; i < n; i++) temp[i] = a[i] & mask;
   return ct_bn_add_words(r, r, temp, n);
 }
 
 static BN_ULONG cnd_sub_words(int n, BN_ULONG r[], bool flag, const BN_ULONG a[]) {
+  cb_assert(n > 0 && n <= MAX_MODULUS_WORDS);
   BN_ULONG mask = constant_time_mask_ulong(flag);
+  // Intentional bounded VLA: preserving the temp array keeps ct_bn_sub_words()'s borrow chain optimizable.
   BN_ULONG temp[n];
   for (int i = 0; i < n; i++) temp[i] = a[i] & mask;
   return ct_bn_sub_words(r, r, temp, n);
 }
 
 static BN_ULONG cnd_neg_words(int n, BN_ULONG r[], bool flag) {
+  cb_assert(n > 0 && n <= MAX_MODULUS_WORDS);
   BN_ULONG mask = constant_time_mask_ulong(flag);
   for (int i = 0; i < n; i++) r[i] ^= mask;
+  // Intentional bounded VLA: see cnd_add_words().
   BN_ULONG temp[n];
   std::fill(temp, temp + n, 0);
   temp[0] = (BN_ULONG)flag;
@@ -252,6 +267,8 @@ void mod_t::scr_inv(bn_t& res, const bn_t& in) const {
   r->top = n;
 
   const BN_ULONG* m = q->d;
+  cb_assert(n > 0 && n <= MAX_MODULUS_WORDS);
+  // Intentional bounded VLAs: n is capped by MAX_MODULUS_BITS. These buffers are hot scratch state for SCR inversion.
   BN_ULONG a[n];
   auto top = std::min(x->top, n);
   std::copy(x->d, x->d + top, a);
@@ -369,6 +386,8 @@ bn_t mod_t::mul_mont(const bn_t& x, const bn_t& y) const {
 }
 
 void mod_t::init(const bn_t& m) {
+  cb_assert(m.get_bits_count() <= MAX_MODULUS_BITS && "modulus too large");
+
   if (!mont) mont = BN_MONT_CTX_new();
   if (!mont) throw std::bad_alloc();
 
@@ -440,12 +459,16 @@ void mod_t::_mod(BIGNUM& r, const BIGNUM& x) const {
   BIGNUM q1 = bn_skip(x, k - 1);  // q1 = x / b^(k-1)
 
   int q2_len = q1.top + mu.top;
+  cb_assert(k <= MAX_MODULUS_WORDS);
+  cb_assert(q2_len <= 2 * MAX_MODULUS_WORDS + 2);
+  // Intentional bounded VLA: q2_len is derived from operands capped by MAX_MODULUS_BITS.
   BN_ULONG q2_buf[q2_len];
   BIGNUM q2 = bn_buf(q2_buf, q2_len);
   bn_mul_normal(q2.d, q1.d, q1.top, mu.d, mu.top);  // q2 = q1 * mu;
 
   BIGNUM q3 = bn_skip(q2, k + 1);  // q3 = q2 / b^(k+1)
 
+  // Intentional bounded VLA: k <= MAX_MODULUS_WORDS.
   BN_ULONG r2_buf[k + 1];
   BIGNUM r2 = bn_buf(r2_buf, k + 1);
   barrett_partial_mul(r2.top, r2.d, q3.top, q3.d, mm.top, mm.d);  // r2 = partial_mul<k + 1>(q3, modulus);

--- a/tests/unit/crypto/test_base_mod.cpp
+++ b/tests/unit/crypto/test_base_mod.cpp
@@ -35,6 +35,10 @@ TEST(Mod, Initialization) {
   // Paillier/RSA Modulo
   EXPECT_NO_FATAL_FAILURE(mod_t(bn_t::generate_prime(2048, false) * bn_t::generate_prime(2048, false)));
 
+  bn_t oversized_modulus = (bn_t(1) << mod_t::MAX_MODULUS_BITS) + 1;
+  EXPECT_FALSE(mod_t::is_valid_modulus(oversized_modulus));
+  EXPECT_CB_ASSERT((mod_t(oversized_modulus)), "modulus too large");
+
   dylog_disable_scope_t no_log_err;
   EXPECT_CB_ASSERT(mod_t(100), "BN_MONT_CTX_set failed");
   EXPECT_CB_ASSERT(mod_t(bn_t::rand_bitlen(256) * 2), "BN_MONT_CTX_set failed");


### PR DESCRIPTION
Cap mod_t moduli at 8192 bits before using stack scratch buffers, and add assertions around bounded VLA allocations in modular arithmetic.

Honor CBMPC_OPENSSL_ROOT in the platform OpenSSL build scripts and document native Linux/macOS build targets.

Resolves #108